### PR TITLE
Add buildkite set up to build packages and docker

### DIFF
--- a/.buildkite/env/secrets.ejson
+++ b/.buildkite/env/secrets.ejson
@@ -1,0 +1,6 @@
+{
+  "_public_key": "4da2b52855505e4af8c48d6dea31da6431ae7a19acef5d1ea0f2121cc8760334",
+  "environment": {
+  	"PACKAGECLOUD_API_KEY": "EJ[1:hA6z/9BUNCsCGFAYYCidExwhTwdqgCik79GNsivcflY=:NqUGHDzae4LP9YN9bGA+j9t51L9a+uIZ:ZGMBwTiCQggE1Rog3ysjfmsFMiC+Zpn/Ux0Tw32DrHLpt8P2L8FJHfq/ibKy4YMj7HLlCb29c9ahqi39E0lmPw==]"
+  }
+}

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+echo '--- :house_with_garden: Setting up the environment'
+
+. "$HOME/.asdf/asdf.sh"
+asdf local erlang 22.1.8
+asdf local python 3.7.3
+asdf local ruby 2.6.2
+
+export EJSON_KEYDIR="$HOME/.ejson"
+eval "$(ejson2env .buildkite/env/secrets.ejson)"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,39 @@
+steps:
+  - label: ":hammer: running tests"
+    commands:
+      - "make ci"
+    key: "tests"
+    agents:
+      queue: "erlang"
+
+  - label: ":debian: build deb"
+    commands:
+      - "git fetch -t"
+      - "make release"
+      - ".buildkite/scripts/make_deb.sh"
+    key: "deb"
+    artifact_paths: "*.deb"
+    if: build.tag != null
+    depends_on: "tests"
+    agents:
+      queue: "erlang"
+
+  - label: "upload"
+    name: ":cloud: upload to packagecloud"
+    commands:
+      - "git fetch -t"
+      - ".buildkite/scripts/packagecloud_upload.sh"
+    if: build.tag != null
+    depends_on: "deb"
+    agents:
+      queue: "erlang"
+
+  - label: "docker"
+    name: ":whale: build docker"
+    commands:
+      - "git fetch -t"
+      - ".buildkite/scripts/make_docker.sh"
+    if: build.tag != null
+    depends_on: "deb"
+    agents:
+      queue: "erlang"

--- a/.buildkite/scripts/Dockerfile
+++ b/.buildkite/scripts/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:18.04
+
+EXPOSE 8080
+
+COPY .buildkite/scripts/lager_console_setup.pl /
+RUN perl -i lager_console_setup.pl /var/helium/blockchain_http/releases/0.1.0/sys.config
+RUN rm -f lager_console_setup.pl
+
+RUN apt update
+RUN apt install -y libssl1.1 libsodium23
+RUN apt clean
+
+COPY blockchain-http*.deb /
+RUN dpkg -i blockchain-http*.deb
+RUN rm -f blockchain-http*.deb
+RUN touch /var/helium/blockchain_http/.env

--- a/.buildkite/scripts/lager_console_setup.pl
+++ b/.buildkite/scripts/lager_console_setup.pl
@@ -1,0 +1,18 @@
+#!/usr/bin/env perl
+
+$done = 0;
+while (<>) {
+
+	if (/lager_file_backend/ and not $done) {
+		$done = 1;
+		print "     {lager_console_backend, [{level, debug}]}\n";
+	}
+	elsif (/lager_file_backend/ and $done) {
+	}
+	elsif (/colored/) {
+		print "   {colored, false},\n";
+	}
+	else {
+		print "$_";
+	}
+}

--- a/.buildkite/scripts/make_deb.sh
+++ b/.buildkite/scripts/make_deb.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+TMPDIR_NAME="/var/lib/tmp"
+
+fpm --workdir "$TMPDIR_NAME" \
+    -n $(basename $(pwd)) \
+    -v $(git describe --long --always) \
+    -s dir \
+    -t deb \
+    _build/prod/rel/=/var/helium

--- a/.buildkite/scripts/make_docker.sh
+++ b/.buildkite/scripts/make_docker.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+DEV_ECS_REGISTRY_NAME="217417705465.dkr.ecr.us-west-2.amazonaws.com/dev-deploy"
+PROD_ECS_REGISTRY_NAME="350169207474.dkr.ecr.us-west-2.amazonaws.com/prod-deploy"
+DEB_PKG="$(basename $(pwd))_$(git describe --long --always)_amd64.deb"
+DOCKER_NAME="$(basename $(pwd))_${BUILDKITE_TAG}"
+
+buildkite-agent artifact download $DEB_PKG .
+
+$(aws ecr get-login --no-include-email --region us-west-2 --registry-ids 350169207474 217417705465)
+
+docker build -t helium:$DOCKER_NAME -f .buildkite/scripts/Dockerfile .
+docker tag helium:$DOCKER_NAME "$DEV_ECS_REGISTRY_NAME:$DOCKER_NAME"
+docker tag helium:$DOCKER_NAME "$PROD_ECS_REGISTRY_NAME:$DOCKER_NAME"
+docker push "$DEV_ECS_REGISTRY_NAME:$DOCKER_NAME"
+docker push "$PROD_ECS_REGISTRY_NAME:$DOCKER_NAME"

--- a/.buildkite/scripts/make_docker.sh
+++ b/.buildkite/scripts/make_docker.sh
@@ -9,10 +9,12 @@ DOCKER_NAME="$(basename $(pwd))_${BUILDKITE_TAG}"
 
 buildkite-agent artifact download $DEB_PKG .
 
-$(aws ecr get-login --no-include-email --region us-west-2 --registry-ids 350169207474 217417705465)
-
 docker build -t helium:$DOCKER_NAME -f .buildkite/scripts/Dockerfile .
 docker tag helium:$DOCKER_NAME "$DEV_ECS_REGISTRY_NAME:$DOCKER_NAME"
 docker tag helium:$DOCKER_NAME "$PROD_ECS_REGISTRY_NAME:$DOCKER_NAME"
+
+$(aws ecr get-login --no-include-email --region us-west-2 --registry-ids 217417705465)
 docker push "$DEV_ECS_REGISTRY_NAME:$DOCKER_NAME"
+
+$(aws ecr get-login --no-include-email --region us-west-2 --registry-ids 350169207474)
 docker push "$PROD_ECS_REGISTRY_NAME:$DOCKER_NAME"

--- a/.buildkite/scripts/packagecloud_upload.sh
+++ b/.buildkite/scripts/packagecloud_upload.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+PKGNAME="$(basename $(pwd))_$(git describe --long --always)_amd64.deb"
+
+buildkite-agent artifact download ${PKGNAME} .
+
+curl -u "${PACKAGECLOUD_API_KEY}:" \
+     -F "package[distro_version_id]=190" \
+     -F "package[package_file]=@${PKGNAME}" \
+     https://packagecloud.io/api/v1/repos/helium/internal/packages.json

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ test:
 ci:
 	$(REBAR) as test do eunit,ct,cover && $(REBAR) do xref, dialyzer
 	$(REBAR) covertool generate
-	codecov --required -f _build/test/covertool/blockchain_etl.covertool.xml
+	#codecov --required -f _build/test/covertool/blockchain_http.covertool.xml
 
 typecheck:
 	$(REBAR) dialyzer
@@ -39,7 +39,7 @@ doc:
 	$(REBAR) edoc
 
 release:
-	$(REBAR) release
+	$(REBAR) as prod do release
 
 
 start:

--- a/rebar.config
+++ b/rebar.config
@@ -11,6 +11,10 @@
   {apps, [lager]}
  ]}.
 
+{project_plugins,
+ [
+  covertool
+ ]}.
 
 {deps,
  [

--- a/test/ct/blockchain_http_SUITE.erl
+++ b/test/ct/blockchain_http_SUITE.erl
@@ -1,0 +1,9 @@
+-module(blockchain_http_SUITE).
+-compile([nowarn_export_all, export_all]).
+
+all() -> [
+          a_test
+         ].
+
+a_test(_Config) ->
+    ok.


### PR DESCRIPTION
Problem to solve: We want to automatically build blockchain-http deb packages and docker containers.

Solution: Set up buildkite along the same lines as blockchain-etl