### PR TITLE
Add console backend for Docker logging

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -33,6 +33,7 @@
    {colored, true},
    {handlers,
     [
+     {lager_console_backend, [{level, debug}]},
      {lager_file_backend, [{file, "console.log"}, {level, info}]},
      {lager_file_backend, [{file, "error.log"}, {level, error}]}
     ]}


### PR DESCRIPTION
Problem to solve: Docker doesn't export logs from files. It just scrapes standard out/err and pipes it to Cloud Watch

Solution: Make lager write everything to the console. Set at debug level for now.