### PR TITLE
Ensure lager fix runs after software install

### DIFF
--- a/.buildkite/scripts/Dockerfile
+++ b/.buildkite/scripts/Dockerfile
@@ -2,10 +2,6 @@ FROM ubuntu:18.04
 
 EXPOSE 8080
 
-COPY .buildkite/scripts/lager_console_setup.pl /
-RUN perl -i lager_console_setup.pl /var/helium/blockchain_http/releases/0.1.0/sys.config
-RUN rm -f lager_console_setup.pl
-
 RUN apt update
 RUN apt install -y libssl1.1 libsodium23
 RUN apt clean
@@ -14,3 +10,7 @@ COPY blockchain-http*.deb /
 RUN dpkg -i blockchain-http*.deb
 RUN rm -f blockchain-http*.deb
 RUN touch /var/helium/blockchain_http/.env
+
+COPY .buildkite/scripts/lager_console_setup.pl /
+RUN perl -i lager_console_setup.pl /var/helium/blockchain_http/releases/0.1.0/sys.config
+RUN rm -f lager_console_setup.pl


### PR DESCRIPTION
Problem to solve: The simplest logging solution for `awsvpc` style ECS workloads is printing to the console. During the container build process a script modifies the stock lager configuration to point to the console. As part of PR cleanup the script execution was moved *before* the config file exists, which caused a silent failure.

Solution: Execute the script in the right place.