### PR TITLE
Use async epqsql functions and dispcount transactions

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -33,7 +33,7 @@
   {psql_migration, {git, "https://github.com/helium/psql-migration.git", {branch, "master"}}},
   {helium_proto, {git, "https://github.com/helium/proto.git", {branch, "master"}}},
   {envloader, {git, "https://github.com/nuex/envloader.git", {branch, "master"}}},
-  {dispcount, {git, "https://github.com/Vagabond/dispcount", {branch, "integration"}}}
+  {dispcount, {git, "https://github.com/Vagabond/dispcount", {branch, "adt/transaction"}}}
  ]}.
 
 {xref_checks,

--- a/rebar.lock
+++ b/rebar.lock
@@ -3,7 +3,7 @@
  {<<"base64url">>,{pkg,<<"base64url">>,<<"1.0.1">>},0},
  {<<"dispcount">>,
   {git,"https://github.com/Vagabond/dispcount",
-       {ref,"1f22b5d7f964a740eb788810da490d8b0f989ddf"}},
+       {ref,"147f996c06c5ec76a0a5cdb1d12b52fd8acd4f7d"}},
   0},
  {<<"ecc_compact">>,{pkg,<<"ecc_compact">>,<<"1.0.4">>},1},
  {<<"elli">>,{pkg,<<"elli">>,<<"3.2.0">>},0},

--- a/src/bh_db_worker.erl
+++ b/src/bh_db_worker.erl
@@ -3,7 +3,7 @@
 -include("bh_route_handler.hrl").
 -include_lib("epgsql/include/epgsql.hrl").
 
--callback prepare_conn(epgsql:connection()) -> ok.
+-callback prepare_conn(epgsql:connection()) -> map().
 
 -behaviour(dispcount).
 

--- a/src/bh_db_worker.erl
+++ b/src/bh_db_worker.erl
@@ -1,6 +1,7 @@
 -module(bh_db_worker).
 
 -include("bh_route_handler.hrl").
+-include_lib("epgsql/include/epgsql.hrl").
 
 -callback prepare_conn(epgsql:connection()) -> ok.
 
@@ -11,7 +12,7 @@
 %% how many times to try to get a worker
 -define(POOL_CHECKOUT_RETRIES, 3).
 
--export([init/1, checkout/2, checkin/2, handle_info/2, dead/1,
+-export([init/1, checkout/2, transaction/3, checkin/2, handle_info/2, dead/1,
          terminate/2, code_change/3]).
 
 -export([squery/2, equery/3, prepared_query/3]).
@@ -19,7 +20,10 @@
 -record(state,
         {
          given = false :: boolean(),
-         db_conn :: epgsql:connection()
+         db_conn :: epgsql:connection(),
+         conn_ref :: reference(),
+         handlers :: [atom()],
+         prepared_statements = #{} :: map()
         }).
 
 
@@ -27,9 +31,15 @@
 squery(Pool, Sql) ->
     case do_checkout(Pool, ?POOL_CHECKOUT_RETRIES) of
         {ok, Reference, Conn} ->
-            Res = epgsql:squery(Conn, Sql),
+            Ref = epgsqla:squery(Conn, Sql),
             dispcount:checkin(Pool, Reference, Conn),
-            Res;
+            receive
+                {Conn, Ref, Res} ->
+                    Res
+            after
+                500 ->
+                    throw(?RESPONSE_503)
+            end;
         {error, busy} ->
             throw(?RESPONSE_503)
     end.
@@ -38,45 +48,74 @@ squery(Pool, Sql) ->
 equery(Pool, Stmt, Params) ->
     case do_checkout(Pool, ?POOL_CHECKOUT_RETRIES) of
         {ok, Reference, Conn} ->
-            Res = epgsql:equery(Conn, Stmt, Params),
-            dispcount:checkin(Pool, Reference, Conn),
-            Res;
+            case epgsql:parse(Conn, Stmt) of
+                {ok, #statement{types = Types} = Statement} ->
+                    TypedParameters = lists:zip(Types, Params),
+                    Ref = epgsqla:equery(Conn, Statement, TypedParameters),
+                    dispcount:checkin(Pool, Reference, Conn),
+                    receive
+                        {Conn, Ref, Res} ->
+                            Res
+                    after
+                        500 ->
+                            throw(?RESPONSE_503)
+                    end;
+                Error ->
+                    dispcount:checkin(Pool, Reference, Conn),
+                    lager:warning("failed to parse query ~p : ~p", [Stmt, Error]),
+                    throw({500, [], <<"Internal server error">>})
+            end;
         {error, busy} ->
             throw(?RESPONSE_503)
     end.
 
 -spec prepared_query(Pool::term(), Name::string(), Params::[epgsql:bind_param()]) -> epgsql_cmd_prepared_query:response().
 prepared_query(Pool, Name, Params) ->
-    case do_checkout(Pool, ?POOL_CHECKOUT_RETRIES) of
-        {ok, Reference, Conn} ->
-            Res = epgsql:prepared_query(Conn, Name, Params),
-            dispcount:checkin(Pool, Reference, Conn),
-            Res;
+    Ref = make_ref(),
+    Fun = fun(From, {Stmts, Conn}) ->
+                  Statement = maps:get(Name, Stmts),
+                  #statement{types = Types} = Statement,
+                  TypedParameters = lists:zip(Types, Params),
+                  %% construct the same kind of cast the epgsqla:prepared_statement does, but redirect
+                  %% the output to the elli process directly
+                  gen_server:cast(Conn, {{cast, From, Ref}, epgsql_cmd_prepared_query, {Statement, TypedParameters}})
+          end,
+    case dispcount:transaction(Pool, Fun) of
+        ok ->
+            receive
+                {_Conn, Ref, Res} ->
+                    Res
+            after
+                500 ->
+                    throw(?RESPONSE_503)
+            end;
         {error, busy} ->
             throw(?RESPONSE_503)
     end.
 
 init(Args) ->
-    process_flag(trap_exit, true),
     GetOpt = fun(K) ->
                      case lists:keyfind(K, 1, Args) of
                          false -> error({missing_opt, K});
                          {_, V} -> V
                      end
              end,
-    DBOpts = GetOpt(db_opts),
+    #{host := Host, username := Username, password := Password} = DBOpts = GetOpt(db_opts),
     Codecs = [{epgsql_codec_json, {jiffy, [], [return_maps]}}],
-    {ok, Conn} = epgsql:connect(DBOpts#{codecs => Codecs}),
-    lists:foreach(fun(Mod) ->
-                          Mod:prepare_conn(Conn)
-                  end, GetOpt(db_handlers)),
-    {ok, #state{db_conn=Conn}}.
+    {ok, Conn} = epgsqla:start_link(),
+    %% there's not an async connect that just takes Conn and Opts, for some reason
+    Ref = epgsqla:connect(Conn, Host, Username, Password, DBOpts#{codecs => Codecs}),
+    {ok, #state{db_conn=Conn, conn_ref=Ref, given=true, handlers=GetOpt(db_handlers)}}.
 
 checkout(_From, State = #state{given=true}) ->
     lager:warning("unexpected checkout when already checked out"),
     {error, busy, State};
 checkout(_From, State = #state{db_conn = Conn}) ->
     {ok, Conn, State#state{given=true}}.
+
+transaction(From, Fun, State = #state{db_conn=Conn, prepared_statements=Stmts}) ->
+    Fun(From, {Stmts, Conn}),
+    {ok, State}.
 
 checkin(Conn, State = #state{db_conn = Conn, given=true}) ->
     {ok, State#state{given=false}};
@@ -87,11 +126,19 @@ checkin(Conn, State) ->
 dead(State) ->
     {ok, State#state{given=false}}.
 
+handle_info({Conn, Ref, connected}, State = #state{db_conn=Conn, conn_ref=Ref, handlers=Handlers}) ->
+    %% connection is ready now
+    PreparedStatements = lists:foldl(fun(Mod, Acc) ->
+                                             maps:merge(Mod:prepare_conn(Conn), Acc)
+                                     end, #{}, Handlers),
+    {ok, State#state{given=false, prepared_statements=PreparedStatements}};
+handle_info({Conn, Ref, {error, Reason}}, State = #state{db_conn=Conn, conn_ref=Ref}) ->
+    {stop, {error, Reason}, State};
 handle_info({'EXIT', Conn, Reason}, State = #state{db_conn=Conn}) ->
     lager:info("dispcount worker's db connection exited ~p", [Reason]),
     {stop, Reason, State};
 handle_info(_Msg, State) ->
-    lager:info("dispcount worker got unexpected message ~p", [_Msg]),
+    lager:info("dispcount worker got unexpected message ~p ~p", [_Msg, State]),
     {ok, State}.
 
 terminate(_Reason, _State) ->

--- a/src/bh_route_hotspots.erl
+++ b/src/bh_route_hotspots.erl
@@ -22,22 +22,24 @@
         "l.short_street, l.long_street, l.short_city, l.long_city, l.short_state, l.long_state, l.short_country, l.long_country from gateway_ledger g left join locations l on g.location = l.location ").
 
 prepare_conn(Conn) ->
-    {ok, _} = epgsql:parse(Conn, ?S_HOTSPOT_LIST_BEFORE,
+    {ok, S1} = epgsql:parse(Conn, ?S_HOTSPOT_LIST_BEFORE,
                            ?SELECT_HOTSPOT_BASE "where g.address > $1 order by first_block desc, address limit $2", []),
 
-    {ok, _} = epgsql:parse(Conn, ?S_HOTSPOT_LIST,
+    {ok, S2} = epgsql:parse(Conn, ?S_HOTSPOT_LIST,
                            ?SELECT_HOTSPOT_BASE "order by first_block desc, address limit $1", []),
 
-    {ok, _} = epgsql:parse(Conn, ?S_OWNER_HOTSPOT_LIST_BEFORE,
+    {ok, S3} = epgsql:parse(Conn, ?S_OWNER_HOTSPOT_LIST_BEFORE,
                            ?SELECT_HOTSPOT_BASE "where g.owner = $1 and g.address > $2 order by first_block desc, address limit $3", []),
 
-    {ok, _} = epgsql:parse(Conn, ?S_OWNER_HOTSPOT_LIST,
+    {ok, S4} = epgsql:parse(Conn, ?S_OWNER_HOTSPOT_LIST,
                            ?SELECT_HOTSPOT_BASE "where g.owner = $1 order by first_block desc, address limit $2", []),
 
-    {ok, _} = epgsql:parse(Conn, ?S_HOTSPOT,
+    {ok, S5} = epgsql:parse(Conn, ?S_HOTSPOT,
                            ?SELECT_HOTSPOT_BASE "where g.address = $1", []),
 
-    ok.
+    #{?S_HOTSPOT_LIST_BEFORE => S1, ?S_HOTSPOT_LIST => S2,
+      ?S_OWNER_HOTSPOT_LIST_BEFORE => S3, ?S_OWNER_HOTSPOT_LIST => S4,
+      ?S_HOTSPOT => S5}.
 
 
 handle('GET', [], Req) ->

--- a/src/bh_route_pending_txns.erl
+++ b/src/bh_route_pending_txns.erl
@@ -21,16 +21,17 @@
 -define(SELECT_PENDING_TXN_BASE, "select t.created_at, t.updated_at, t.hash, t.status, t.failed_reason from pending_transactions t ").
 
 prepare_conn(Conn) ->
-    {ok, _} = epgsql:parse(Conn, ?S_PENDING_TXN_LIST_BEFORE,
+    {ok, S1} = epgsql:parse(Conn, ?S_PENDING_TXN_LIST_BEFORE,
                            ?SELECT_PENDING_TXN_BASE "where t.created_at < $2 and t.status = $1 order by created_at DESC limit $3", []),
 
-    {ok, _} = epgsql:parse(Conn, ?S_PENDING_TXN,
+    {ok, S2} = epgsql:parse(Conn, ?S_PENDING_TXN,
                            ?SELECT_PENDING_TXN_BASE "where hash = $1", []),
 
-    {ok, _} = epgsql:parse(Conn, ?S_INSERT_PENDING_TXN,
+    {ok, S3} = epgsql:parse(Conn, ?S_INSERT_PENDING_TXN,
                            "insert into pending_transactions (hash, type, address, nonce, nonce_type, status, data) values ($1, $2, $3, $4, $5, $6, $7)", []),
 
-    ok.
+    #{?S_PENDING_TXN_LIST_BEFORE => S1, ?S_PENDING_TXN => S2,
+      ?S_INSERT_PENDING_TXN => S3}.
 
 handle('GET', [TxnHash], _Req) ->
     ?MK_RESPONSE(get_pending_txn(TxnHash));

--- a/src/bh_route_txns.erl
+++ b/src/bh_route_txns.erl
@@ -23,23 +23,24 @@
         "from transaction_actors a inner join transactions t on a.transaction_hash = t.hash " ).
 
 prepare_conn(Conn) ->
-    {ok, _} = epgsql:parse(Conn, ?S_TXN,
+    {ok, S1} = epgsql:parse(Conn, ?S_TXN,
                           ?SELECT_TXN_BASE "where t.hash = $1", []),
 
-    {ok, _} = epgsql:parse(Conn, ?S_TXN_LIST,
+    {ok, S2} = epgsql:parse(Conn, ?S_TXN_LIST,
                            ?SELECT_TXN_BASE "where t.type = ANY($1) order by block desc limit $2", []),
 
-    {ok, _} = epgsql:parse(Conn, ?S_TXN_LIST_BEFORE,
+    {ok, S3} = epgsql:parse(Conn, ?S_TXN_LIST_BEFORE,
                            ?SELECT_TXN_BASE "where t.type  = ANY($1) and t.block < $2 order by block desc limit $3", []),
 
-    {ok, _} = epgsql:parse(Conn, ?S_ACTOR_TXN_LIST,
+    {ok, S4} = epgsql:parse(Conn, ?S_ACTOR_TXN_LIST,
                            ?SELECT_ACTOR_TXN_BASE "where a.actor = $1 and t.type = ANY($2) order by block desc limit $3", []),
 
-    {ok, _} = epgsql:parse(Conn, ?S_ACTOR_TXN_LIST_BEFORE,
+    {ok, S5} = epgsql:parse(Conn, ?S_ACTOR_TXN_LIST_BEFORE,
                            ?SELECT_ACTOR_TXN_BASE "where a.actor = $1 and t.type = ANY($2) and t.block < $3 order by block desc limit $4", []),
 
-    ok.
-
+    #{?S_TXN => S1, ?S_TXN_LIST => S2,
+      ?S_TXN_LIST_BEFORE => S3, ?S_ACTOR_TXN_LIST => S4,
+      ?S_ACTOR_TXN_LIST_BEFORE => S5}.
 
 handle('GET', [], Req) ->
     Args = ?GET_ARGS([filter_types, before, limit], Req),

--- a/src/bh_sup.erl
+++ b/src/bh_sup.erl
@@ -78,6 +78,7 @@ init([]) ->
     {ok, RWPoolInfo} = dispcount:dispatcher_info(rw_pool),
     persistent_term:put(rw_pool, RWPoolInfo),
 
+
     lager:info("Starting http listener on ~p", [ListenPort]),
     ChildSpecs =
         [
@@ -85,3 +86,4 @@ init([]) ->
         ],
 
     {ok, {SupFlags, ChildSpecs}}.
+


### PR DESCRIPTION
To increase pipelining and to hold the lock on the db connections for
less time, use epgsql's async query support. Additionally do connection
initialization asynchronously to allow the service to start a bit
faster.

Finally, for prepared statements attempt to use the new dispcount
transactions mode that runs a fun that was casted to the worker. This
avoids the caller having to wait for the checkout response and then do a
checkin which should translate to less waiting. We also trick epgsql
into sending the result back to the elli process, not the pool process
which should also improve performance.