### PR TITLE
Validate empty arguments and block height

### DIFF
--- a/src/bh_route_blocks.erl
+++ b/src/bh_route_blocks.erl
@@ -69,8 +69,13 @@ get_block_list([{before, undefined}, {limit, Limit}]) ->
     {ok, _, Results} = ?PREPARED_QUERY(?S_BLOCK_LIST, [Limit]),
     {ok, block_list_to_json(Results)};
 get_block_list([{before, Before}, {limit, Limit}]) ->
-    {ok, _, Results} = ?PREPARED_QUERY(?S_BLOCK_LIST_BEFORE, [Before, Limit]),
-    {ok, block_list_to_json(Results)}.
+    case catch binary_to_integer(Before) of
+        {'EXIT', _} ->
+            get_block_list([{before, undefined}, {limit, Limit}]);
+        Height ->
+            {ok, _, Results} = ?PREPARED_QUERY(?S_BLOCK_LIST_BEFORE, [Height, Limit]),
+            {ok, block_list_to_json(Results)}
+    end.
 
 get_block_height() ->
     {ok, _, [{Height}]} = ?PREPARED_QUERY(?S_BLOCK_HEIGHT, []),

--- a/src/bh_route_blocks.erl
+++ b/src/bh_route_blocks.erl
@@ -54,11 +54,10 @@ handle('GET', [<<"height">>], _Req) ->
 handle('GET', [<<"hash">>, BlockHash], _Req) ->
     ?MK_RESPONSE(get_block_by_hash(BlockHash));
 handle('GET', [BlockId], _Req) ->
-    case catch binary_to_integer(BlockId) of
-        {'EXIT', _} ->
-            ?RESPONSE_400;
-        Height ->
-            ?MK_RESPONSE(get_block_by_height(Height))
+    try binary_to_integer(BlockId) of
+        Height -> ?MK_RESPONSE(get_block_by_height(Height))
+    catch _:_ ->
+        ?RESPONSE_400
     end;
 
 handle(_Method, _Path, _Req) ->
@@ -69,12 +68,12 @@ get_block_list([{before, undefined}, {limit, Limit}]) ->
     {ok, _, Results} = ?PREPARED_QUERY(?S_BLOCK_LIST, [Limit]),
     {ok, block_list_to_json(Results)};
 get_block_list([{before, Before}, {limit, Limit}]) ->
-    case catch binary_to_integer(Before) of
-        {'EXIT', _} ->
-            get_block_list([{before, undefined}, {limit, Limit}]);
+    try binary_to_integer(Before) of
         Height ->
             {ok, _, Results} = ?PREPARED_QUERY(?S_BLOCK_LIST_BEFORE, [Height, Limit]),
             {ok, block_list_to_json(Results)}
+    catch _:_ ->
+            get_block_list([{before, undefined}, {limit, Limit}])
     end.
 
 get_block_height() ->

--- a/src/bh_route_handler.erl
+++ b/src/bh_route_handler.erl
@@ -29,7 +29,10 @@ get_args([{limit, Default} | Tail], Req, Acc) ->
 get_args([Key | Tail], Req, Acc) when is_atom(Key) ->
     get_args([{Key, undefined} | Tail], Req, Acc);
 get_args([{Key, Default} | Tail], Req, Acc) ->
-    V = elli_request:get_arg_decoded(atom_to_binary(Key, latin1), Req, Default),
+    V = case elli_request:get_arg_decoded(atom_to_binary(Key, latin1), Req, Default) of
+            <<>> -> Default;
+            Arg -> Arg
+        end,
     get_args(Tail, Req, [{Key, V} | Acc]).
 
 mk_response({ok, Json}) ->

--- a/src/bh_route_handler.erl
+++ b/src/bh_route_handler.erl
@@ -21,11 +21,11 @@ get_args([limit | Tail], Req, Acc) ->
     get_args([{limit, ?DEFAULT_ARG_LIMIT} | Tail], Req, Acc);
 get_args([{limit, Default} | Tail], Req, Acc) ->
     V = elli_request:get_arg_decoded(<<"limit">>, Req, Default),
-    N = case catch binary_to_integer(V) of
-            {'EXIT', _} -> binary_to_integer(?DEFAULT_ARG_LIMIT);
-            NumVal -> NumVal
-        end,
-    get_args(Tail, Req, [{limit, min(?MAX_LIMIT, N)} | Acc]);
+    try binary_to_integer(V) of
+        N ->  get_args(Tail, Req, [{limit, min(?MAX_LIMIT, N)} | Acc])
+    catch _:_ ->
+            binary_to_integer(?DEFAULT_ARG_LIMIT)
+    end;
 get_args([Key | Tail], Req, Acc) when is_atom(Key) ->
     get_args([{Key, undefined} | Tail], Req, Acc);
 get_args([{Key, Default} | Tail], Req, Acc) ->


### PR DESCRIPTION
* Checks for an empty value as an argument and replaces it with the "default" value for the argument
* Actually converts the block height to a number for the blocks routes