### PR TITLE
Make read only pool size settable using an environment variable

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -5,7 +5,7 @@
    {port, 8080},
    {db_ro_pool,
     [
-     {size, 1000},
+     {size, 100},
      {watcher_type, atomics}, %% ets, named, or atomics
      {dispatch_mechanism, round_robin} %% hash or round_robin
     ]},

--- a/src/bh_sup.erl
+++ b/src/bh_sup.erl
@@ -34,6 +34,7 @@ init([]) ->
     {ok, RW_DBHandlers} = application:get_env(blockchain_http, db_rw_handlers),
 
     {ok, RO_PoolOpts} = application:get_env(blockchain_http, db_ro_pool),
+    RO_PoolSize = os:getenv("DATABASE_RO_POOL_SIZE", proplists:get_value(size, RO_PoolOpts, 100)),
     {ok, RO_DBOpts} = psql_migration:connection_opts([], "DATABASE_RO_URL"),
     {ok, RO_DBHandlers} = application:get_env(blockchain_http, db_ro_handlers),
 
@@ -52,7 +53,7 @@ init([]) ->
           {watcher_type, proplists:get_value(watcher_type, RO_PoolOpts, ets)},
           {maxr,10},
           {maxt,60},
-          {resources, proplists:get_value(size, RO_PoolOpts, 200)}
+          {resources, RO_PoolSize}
          ]),
 
     {ok, ROPoolInfo} = dispcount:dispatcher_info(ro_pool),
@@ -87,4 +88,3 @@ init([]) ->
         ],
 
     {ok, {SupFlags, ChildSpecs}}.
-


### PR DESCRIPTION
Makes the read only pool size settable with a `DATABASE_RO_POOL_SIZE` environment variable. Tye sys.config and fallback default are both set to 100 with this change