### PR TITLE
Improved paging support

### DIFF
--- a/src/bh_db_worker.erl
+++ b/src/bh_db_worker.erl
@@ -121,7 +121,11 @@ checkout(_From, State = #state{db_conn = Conn}) ->
     {ok, Conn, State#state{given=true}}.
 
 transaction(From, Fun, State = #state{db_conn=Conn, prepared_statements=Stmts}) ->
-    Fun(From, {Stmts, Conn}),
+    try Fun(From, {Stmts, Conn}) of
+        _ -> ok
+    catch What:Why:Stack ->
+            lager:warning("Transaction failed: ~p", [{What, Why, Stack}])
+    end,
     {ok, State}.
 
 checkin(Conn, State = #state{db_conn = Conn, given=true}) ->

--- a/src/bh_route_accounts.erl
+++ b/src/bh_route_accounts.erl
@@ -14,55 +14,93 @@
 -define(S_ACCOUNT_LIST, "account_list").
 -define(S_ACCOUNT, "account").
 
--define(SELECT_ACCOUNT_BASE(A), "select l.address, l.dc_balance, l.dc_nonce, l.security_balance, l.security_nonce, l.balance, l.nonce" A " from account_ledger l ").
+-define(SELECT_ACCOUNT_BASE(A), "select (select max(height) from blocks) as height, l.address, l.dc_balance, l.dc_nonce, l.security_balance, l.security_nonce, l.balance, l.nonce, l.first_block" A " from account_ledger l ").
 -define(SELECT_ACCOUNT_BASE, ?SELECT_ACCOUNT_BASE("")).
+
+-define(ACCOUNT_LIST_LIMIT, 100).
 
 prepare_conn(Conn) ->
     {ok, S1} = epgsql:parse(Conn, ?S_ACCOUNT_LIST_BEFORE,
-                           ?SELECT_ACCOUNT_BASE "where l.address > $1 order by first_block desc, address limit $2", []),
+                            [?SELECT_ACCOUNT_BASE,
+                             "where (l.address > $1 and l.first_block = $2) or (l.first_block < $2) ",
+                             "order by first_block desc, address limit ", integer_to_list(?ACCOUNT_LIST_LIMIT)],
+                            []),
 
     {ok, S2} = epgsql:parse(Conn, ?S_ACCOUNT_LIST,
-                           ?SELECT_ACCOUNT_BASE "order by first_block desc, address limit $1", []),
+                             [?SELECT_ACCOUNT_BASE,
+                              "order by first_block desc, address limit ", integer_to_list(?ACCOUNT_LIST_LIMIT)],
+                             []),
 
     {ok, S3} = epgsql:parse(Conn, ?S_ACCOUNT,
-                           ?SELECT_ACCOUNT_BASE(
+                           [?SELECT_ACCOUNT_BASE(
                               ", (select coalesce(max(nonce), l.nonce) from pending_transactions p where p.address = l.address and nonce_type='balance' and status != 'failed') as speculative_nonce"
-                             )
-                           "where l.address = $1", []),
+                             ), "where l.address = $1"],
+                            []),
 
-    #{?S_ACCOUNT_LIST_BEFORE => S1, ?S_ACCOUNT_LIST => S2,
-      ?S_ACCOUNT => S3}.
+    #{?S_ACCOUNT_LIST_BEFORE => S1,
+      ?S_ACCOUNT_LIST => S2,
+      ?S_ACCOUNT => S3 }.
 
 handle('GET', [], Req) ->
-    Args = ?GET_ARGS([before, limit], Req),
+    Args = ?GET_ARGS([cursor], Req),
     ?MK_RESPONSE(get_account_list(Args));
 handle('GET', [Account], _Req) ->
     ?MK_RESPONSE(get_account(Account));
 handle('GET', [Account, <<"hotspots">>], Req) ->
-    Args = ?GET_ARGS([before, limit], Req),
+    Args = ?GET_ARGS([cursor], Req),
     ?MK_RESPONSE(bh_route_hotspots:get_hotspot_list([{owner, Account} | Args]));
-handle('GET', [Account, <<"transactions">>], Req) ->
-    Args = ?GET_ARGS([filter_types, before, limit], Req),
-    ?MK_RESPONSE(bh_route_txns:get_txn_list([{actor, Account} | Args]));
 
 handle(_, _, _Req) ->
     ?RESPONSE_404.
 
-get_account_list([{before, undefined}, {limit, Limit}])  ->
-    {ok, _, Results} = ?PREPARED_QUERY(?S_ACCOUNT_LIST, [Limit]),
-    {ok, account_list_to_json(Results)};
-get_account_list([{before, Before}, {limit, Limit}]) ->
-    {ok, _, Results} = ?PREPARED_QUERY(?S_ACCOUNT_LIST_BEFORE, [Before, Limit]),
-    {ok, account_list_to_json(Results)}.
+get_account_list([{cursor, undefined}])  ->
+    Result = ?PREPARED_QUERY(?S_ACCOUNT_LIST, []),
+    mk_account_list_from_result(undefined, Result);
+get_account_list([{cursor, Cursor}]) ->
+    case ?CURSOR_DECODE(Cursor) of
+        {ok, #{ <<"before_address">> := BeforeAddress,
+                <<"before_block">> := BeforeBlock,
+                <<"height">> := CursorHeight}} ->
+            Result = ?PREPARED_QUERY(?S_ACCOUNT_LIST_BEFORE, [BeforeAddress, BeforeBlock]),
+            mk_account_list_from_result(CursorHeight, Result);
+        _ ->
+            {error, badarg}
+    end.
 
 get_account(Account) ->
     case ?PREPARED_QUERY(?S_ACCOUNT, [Account]) of
         {ok, _, [Result]} ->
             {ok, account_to_json(Result)};
         _ ->
-            {ok, account_to_json({Account, 0, 0, 0, 0, 0, 0, 0})}
+            {ok, account_to_json({null, Account, 0, 0, 0, 0, 0, 0, 0})}
     end.
 
+mk_account_list_from_result(undefined, {ok, _, Results}) ->
+    {ok, account_list_to_json(Results), mk_cursor(Results)};
+mk_account_list_from_result(Height, {ok, _, [{Height, _Address,
+                                             _DCBalance, _DCNonce,
+                                             _SecBalance, _SecNonce,
+                                             _Balance, _Nonce,
+                                             _FirstBlock} | _] = Results}) ->
+    %% The above head ensures that the given cursor height matches the
+    %% height in the results
+    {ok, account_list_to_json(Results), mk_cursor(Results)};
+mk_account_list_from_result(_Height, {ok, _, _}) ->
+    %% For a mismatched height we return a bad argument so the
+    %% requester can re-start
+    {error, badarg}.
+
+
+mk_cursor(Results) when is_list(Results) ->
+    case length(Results) < ?ACCOUNT_LIST_LIMIT of
+        true -> undefined;
+        false ->
+            {Height, Address, _DCBalance, _DCNonce, _SecBalance, _SecNonce, _Balance, _Nonce, FirstBlock} = lists:last(Results),
+            #{ before_address => Address,
+               before_block => FirstBlock,
+               height => Height
+             }
+    end.
 
 %%
 %% json
@@ -71,7 +109,7 @@ get_account(Account) ->
 account_list_to_json(Results) ->
     lists:map(fun account_to_json/1, Results).
 
-account_to_json({Address, DCBalance, DCNonce, SecBalance, SecNonce, Balance, Nonce}) ->
+account_to_json({Height, Address, DCBalance, DCNonce, SecBalance, SecNonce, Balance, Nonce, _FirstBlock}) ->
     #{
       <<"address">> => Address,
       <<"balance">> => Balance,
@@ -79,10 +117,11 @@ account_to_json({Address, DCBalance, DCNonce, SecBalance, SecNonce, Balance, Non
       <<"dc_balance">> => DCBalance,
       <<"dc_nonce">> => DCNonce,
       <<"sec_balance">> => SecBalance,
-      <<"sec_nonce">> => SecNonce
+      <<"sec_nonce">> => SecNonce,
+      <<"block">> => Height
      };
-account_to_json({Address, DCBalance, DCNonce, SecBalance, SecNonce, Balance, Nonce, SpecNonce}) ->
-    Base = account_to_json({Address, DCBalance, DCNonce, SecBalance, SecNonce, Balance, Nonce}),
+account_to_json({Height, Address, DCBalance, DCNonce, SecBalance, SecNonce, Balance, Nonce, FirstBlock, SpecNonce}) ->
+    Base = account_to_json({Height, Address, DCBalance, DCNonce, SecBalance, SecNonce, Balance, Nonce, FirstBlock}),
     Base#{
           <<"speculative_nonce">> => SpecNonce
          }.

--- a/src/bh_route_blocks.erl
+++ b/src/bh_route_blocks.erl
@@ -9,53 +9,85 @@
 %% Utilities
 -export([get_block_height/0,
          get_block_list/1,
-         get_block_by_height/1,
-         get_block_by_hash/1]).
+         get_block_by_height/2,
+         get_block_by_hash/2]).
 
 -define(S_BLOCK_HEIGHT, "block_height").
--define(S_BLOCK_LIST_BEFORE, "block_list_before").
+
 -define(S_BLOCK_LIST, "block_list").
+-define(S_BLOCK_LIST_BEFORE, "block_list_before").
+
 -define(S_BLOCK_BY_HEIGHT, "block_by_height").
--define(S_BLOCK_TXN_LIST, "block_txn_list").
+-define(S_BLOCK_BY_HEIGHT_BEFORE, "block_by_height_before").
+
 -define(S_BLOCK_BY_HASH, "block_by_hash").
--define(S_BLOCK_BY_HASH_TXN_LIST, "block_by_hash_txn_list").
+-define(S_BLOCK_BY_HASH_BEFORE, "block_by_hash_before").
 
 -define(SELECT_BLOCK_BASE, "select b.height, b.time, b.block_hash, b.transaction_count from blocks b ").
--define(SELECT_BLOCK_TXN_BASE,
-        "select b.height, b.time, b.block_hash, b.transaction_count, t.hash, t.type, t.fields "
-        "from blocks b left join transactions t on b.height = t.block ").
+-define(SELECT_BLOCK_TXN_BASE(C),
+        "select * from "
+        "(select b.height, b.time, b.block_hash, b.transaction_count, t.hash, t.type, t.fields "
+        "from blocks b left join transactions t on b.height = t.block "
+        "where b." C " = $1 order by t.hash) r "
+       ).
+
+-define(BLOCK_LIST_LIMIT, 100).
+-define(BLOCK_TXN_LIST_LIMIT, 50).
 
 prepare_conn(Conn) ->
     {ok, S1} = epgsql:parse(Conn, ?S_BLOCK_HEIGHT,
                            "select max(height) from blocks", []),
 
-    {ok, S2} = epgsql:parse(Conn, ?S_BLOCK_LIST_BEFORE,
-                           ?SELECT_BLOCK_BASE "where b.height < $1 order by height DESC limit $2", []),
+    {ok, S2} = epgsql:parse(Conn, ?S_BLOCK_LIST,
+                           [?SELECT_BLOCK_BASE,
+                            "order by height DESC limit (select max(height) % ", integer_to_list(?BLOCK_LIST_LIMIT), " from blocks)"],
+                            []),
 
-    {ok, S3} = epgsql:parse(Conn, ?S_BLOCK_LIST,
-                           ?SELECT_BLOCK_BASE "order by height DESC limit $1", []),
+    {ok, S3} = epgsql:parse(Conn, ?S_BLOCK_LIST_BEFORE,
+                           [?SELECT_BLOCK_BASE,
+                            "where b.height < $1 order by height DESC limit ", integer_to_list(?BLOCK_LIST_LIMIT)],
+                            []),
 
     {ok, S4} = epgsql:parse(Conn, ?S_BLOCK_BY_HEIGHT,
-                           ?SELECT_BLOCK_TXN_BASE "where b.height = $1", []),
+                            [?SELECT_BLOCK_TXN_BASE("height") "limit ", integer_to_list(?BLOCK_TXN_LIST_LIMIT)],
+                            []),
 
-    {ok, S5} = epgsql:parse(Conn, ?S_BLOCK_BY_HASH,
-                           ?SELECT_BLOCK_TXN_BASE "where b.block_hash = $1", []),
+    {ok, S5} = epgsql:parse(Conn, ?S_BLOCK_BY_HEIGHT_BEFORE,
+                           [?SELECT_BLOCK_TXN_BASE("height"),
+                            "where r.hash > $2 limit ", integer_to_list(?BLOCK_TXN_LIST_LIMIT)],
+                            []),
 
-    #{?S_BLOCK_HEIGHT => S1, ?S_BLOCK_LIST_BEFORE => S2,
-      ?S_BLOCK_LIST => S3, ?S_BLOCK_BY_HEIGHT => S4,
-      ?S_BLOCK_BY_HASH => S5}.
+    {ok, S6} = epgsql:parse(Conn, ?S_BLOCK_BY_HASH,
+                           [?SELECT_BLOCK_TXN_BASE("block_hash"),
+                            "limit ", integer_to_list(?BLOCK_TXN_LIST_LIMIT)],
+                            []),
+
+    {ok, S7} = epgsql:parse(Conn, ?S_BLOCK_BY_HASH_BEFORE,
+                           [?SELECT_BLOCK_TXN_BASE("block_hash"),
+                            "where r.hash > $2 limit ", integer_to_list(?BLOCK_TXN_LIST_LIMIT)],
+                            []),
+
+    #{?S_BLOCK_HEIGHT => S1,
+      ?S_BLOCK_LIST => S2,
+      ?S_BLOCK_LIST_BEFORE => S3,
+      ?S_BLOCK_BY_HEIGHT => S4,
+      ?S_BLOCK_BY_HEIGHT_BEFORE => S5,
+      ?S_BLOCK_BY_HASH => S6,
+      ?S_BLOCK_BY_HASH_BEFORE => S7}.
 
 
 handle('GET', [], Req) ->
-    Args = ?GET_ARGS([before, limit], Req),
+    Args = ?GET_ARGS([cursor], Req),
     ?MK_RESPONSE(get_block_list(Args));
 handle('GET', [<<"height">>], _Req) ->
     ?MK_RESPONSE(get_block_height());
-handle('GET', [<<"hash">>, BlockHash], _Req) ->
-    ?MK_RESPONSE(get_block_by_hash(BlockHash));
-handle('GET', [BlockId], _Req) ->
+handle('GET', [<<"hash">>, BlockHash], Req) ->
+    Args = ?GET_ARGS([cursor], Req),
+    ?MK_RESPONSE(get_block_by_hash(BlockHash, Args));
+handle('GET', [BlockId], Req) ->
+    Args = ?GET_ARGS([cursor], Req),
     try binary_to_integer(BlockId) of
-        Height -> ?MK_RESPONSE(get_block_by_height(Height))
+        Height -> ?MK_RESPONSE(get_block_by_height(Height, Args))
     catch _:_ ->
         ?RESPONSE_400
     end;
@@ -64,36 +96,69 @@ handle(_Method, _Path, _Req) ->
     ?RESPONSE_404.
 
 
-get_block_list([{before, undefined}, {limit, Limit}]) ->
-    {ok, _, Results} = ?PREPARED_QUERY(?S_BLOCK_LIST, [Limit]),
-    {ok, block_list_to_json(Results)};
-get_block_list([{before, Before}, {limit, Limit}]) ->
-    try binary_to_integer(Before) of
-        Height ->
-            {ok, _, Results} = ?PREPARED_QUERY(?S_BLOCK_LIST_BEFORE, [Height, Limit]),
-            {ok, block_list_to_json(Results)}
-    catch _:_ ->
-            get_block_list([{before, undefined}, {limit, Limit}])
+get_block_list([{cursor, undefined}]) ->
+    {ok, _, Results} = ?PREPARED_QUERY(?S_BLOCK_LIST, []),
+    {ok, block_list_to_json(Results), mk_cursor(Results)};
+get_block_list([{cursor, Cursor}]) ->
+    case ?CURSOR_DECODE(Cursor) of
+        {ok, #{ <<"before">> := Before}} ->
+            {ok, _, Results} = ?PREPARED_QUERY(?S_BLOCK_LIST_BEFORE, [Before - (Before rem ?BLOCK_LIST_LIMIT)]),
+            {ok, block_list_to_json(Results), mk_cursor(Results)};
+        _ ->
+            {error, badarg}
+    end.
+
+mk_cursor(Results) when is_list(Results) ->
+    case length(Results) of
+        0 -> undefined;
+        _ -> case lists:last(Results) of
+                 {Height, _Time, _Hash, _TxnCount} when Height == 1 -> undefined;
+                 {Height, _Time, _Hash, _TxnCount}  -> #{ before => Height}
+             end
     end.
 
 get_block_height() ->
     {ok, _, [{Height}]} = ?PREPARED_QUERY(?S_BLOCK_HEIGHT, []),
     {ok, #{<<"height">> => Height}}.
 
-get_block_by_height(Height) ->
-    case ?PREPARED_QUERY(?S_BLOCK_BY_HEIGHT, [Height]) of
-        {ok, _, Results} when Results /= []->
-            {ok, block_to_json(Results)};
+get_block_by_height(BlockHeight, [{cursor, undefined}]) ->
+    mk_block_txn_list_from_result(?PREPARED_QUERY(?S_BLOCK_BY_HEIGHT, [BlockHeight]));
+get_block_by_height(BlockHeight, [{cursor, Cursor}]) ->
+    case ?CURSOR_DECODE(Cursor) of
+        {ok, #{ <<"hash">> := TxnHash}} ->
+            Results = ?PREPARED_QUERY(?S_BLOCK_BY_HEIGHT_BEFORE, [BlockHeight, TxnHash]),
+            mk_block_txn_list_from_result(Results);
         _ ->
-            {error, not_found}
+            {error, badarg}
     end.
 
-get_block_by_hash(BlockHash) ->
-    case ?PREPARED_QUERY(?S_BLOCK_BY_HASH, [BlockHash]) of
-        {ok, _, Results} when Results /= [] ->
-            {ok, block_to_json(Results)};
+
+get_block_by_hash(BlockHash, [{cursor, undefined}]) ->
+    Result = ?PREPARED_QUERY(?S_BLOCK_BY_HASH, [BlockHash]),
+    mk_block_txn_list_from_result(Result);
+get_block_by_hash(BlockHash, [{cursor, Cursor}]) ->
+    case ?CURSOR_DECODE(Cursor) of
+        {ok, #{ <<"hash">> := TxnHash}} ->
+            Result = ?PREPARED_QUERY(?S_BLOCK_BY_HASH_BEFORE, [BlockHash, TxnHash]),
+            mk_block_txn_list_from_result(Result);
         _ ->
-            {error, not_found}
+            {error, badarg}
+    end.
+
+mk_block_txn_list_from_result({ok, _, Results}) when Results /= [] ->
+    {ok, block_to_json(Results), mk_block_txn_list_cursor(Results)};
+mk_block_txn_list_from_result(_) ->
+    {error, not_found}.
+
+mk_block_txn_list_cursor(Results) ->
+    case Results of
+        [{_Height, _Time, _Hash, _TxnCount, null, _Type, _Fields}] ->
+            undefined;
+        _ when length(Results) < ?BLOCK_TXN_LIST_LIMIT ->
+            undefined;
+        _ ->
+            {_Height, _Time, _Hash, _TxnCount, TxnHash, _Type, _Fields} = lists:last(Results),
+            #{ hash => TxnHash }
     end.
 
 %%

--- a/src/bh_route_handler.hrl
+++ b/src/bh_route_handler.hrl
@@ -14,6 +14,8 @@
 -define(MK_RESPONSE(R), bh_route_handler:mk_response((R))).
 -define(INSERT_LAT_LON(L, N, F), bh_route_handler:lat_lon((L), (N), (F))).
 -define(INSERT_LAT_LON(L, F), bh_route_handler:lat_lon((L), (F))).
+-define(CURSOR_ENCODE(M), bh_route_handler:cursor_encode(M)).
+-define(CURSOR_DECODE(B), bh_route_handler:cursor_decode(B)).
 
 -define (BIN_TO_B64(B), base64url:encode((B))).
 -define (BIN_TO_B58(B), list_to_binary(libp2p_crypto:bin_to_b58((B)))).


### PR DESCRIPTION
This PR simplifies the request parameters for paging and introduces a cursor construct to help page through lists of data in a more consistent manner. 

Any route that returns a list will return a `cursor` at the same level as the `data` field which holds the response. The cursor can be used to fetch the next page of data. If a cursor is passed as part of the (uri) request, other arguments are ignored. 

Note that page size, previously configurable via the `limit` argument is no longer exposed. 

The following paged routes are affected:

* `/v1/blocks` - only `before` argument is supported on initial request. Page size is 100
* `/v1/blocks/<height>` - page size for transactions in the block is 50. Each page includes the block. The `transactions` field in the block is the list getting paged. 
* `/v1/accounts` - page size is 100
* `/v1/accounts/<address>/hotspots` - equivalent to `/v1/hotspots?owner=<address>`
* `/v1/hotspots`  - Argument `owner` to filter hotspots by owner address is supported.  page size is 100.

**Note** that for the `accounts` and `hotspots` list routes, the current block height of the database is taken into account. This means that the cursor is only valid for as long as the database is at the height the request was made at. Both account and hotspot results include a `block` field to indicate the block height the information was valid for. If you receive a `400` response from the server for a cursor based request, the database has processed a new block. Please start iterating over the accounts/hotspots from the beginning to get a consistent snapshot. 