### PR TITLE
Add account/<x>/activity

### DIFF
--- a/src/bh_route_accounts.erl
+++ b/src/bh_route_accounts.erl
@@ -49,6 +49,9 @@ handle('GET', [Account], _Req) ->
 handle('GET', [Account, <<"hotspots">>], Req) ->
     Args = ?GET_ARGS([cursor], Req),
     ?MK_RESPONSE(bh_route_hotspots:get_hotspot_list([{owner, Account} | Args]));
+handle('GET', [Account, <<"activity">>], Req) ->
+    Args = ?GET_ARGS([cursor, filter_types], Req),
+    ?MK_RESPONSE(bh_route_txns:get_account_activity_list(Account, Args));
 
 handle(_, _, _Req) ->
     ?RESPONSE_404.
@@ -101,6 +104,7 @@ mk_cursor(Results) when is_list(Results) ->
                height => Height
              }
     end.
+
 
 %%
 %% json


### PR DESCRIPTION
Adds support for `/v1/account/<address>/activity`:

* Returns all transactions for the given account 
* Defaults to include all transaction types. You can filter the types of transactions down by passing in a comma separated list of transactions type in the query argument `filter_types`
* Transactions are filtered to subset for activity related to the given account. This means that reward and payment (v2) transactions are filtered down to only include entries related to the given account. 
* Cursor based with a non configuration page size set to 50

Requires: https://github.com/helium/blockchain-etl/pull/33