### PR TITLE
Madninja/cache headers

### DIFF
--- a/src/bh_route_accounts.erl
+++ b/src/bh_route_accounts.erl
@@ -43,15 +43,15 @@ prepare_conn(Conn) ->
 
 handle('GET', [], Req) ->
     Args = ?GET_ARGS([cursor], Req),
-    ?MK_RESPONSE(get_account_list(Args));
+    ?MK_RESPONSE(get_account_list(Args), block_time);
 handle('GET', [Account], _Req) ->
-    ?MK_RESPONSE(get_account(Account));
+    ?MK_RESPONSE(get_account(Account), never);
 handle('GET', [Account, <<"hotspots">>], Req) ->
     Args = ?GET_ARGS([cursor], Req),
-    ?MK_RESPONSE(bh_route_hotspots:get_hotspot_list([{owner, Account} | Args]));
+    ?MK_RESPONSE(bh_route_hotspots:get_hotspot_list([{owner, Account} | Args]), block_time);
 handle('GET', [Account, <<"activity">>], Req) ->
     Args = ?GET_ARGS([cursor, filter_types], Req),
-    ?MK_RESPONSE(bh_route_txns:get_account_activity_list(Account, Args));
+    ?MK_RESPONSE(bh_route_txns:get_account_activity_list(Account, Args), block_time);
 
 handle(_, _, _Req) ->
     ?RESPONSE_404.

--- a/src/bh_route_blocks.erl
+++ b/src/bh_route_blocks.erl
@@ -78,16 +78,20 @@ prepare_conn(Conn) ->
 
 handle('GET', [], Req) ->
     Args = ?GET_ARGS([cursor], Req),
-    ?MK_RESPONSE(get_block_list(Args));
+    CacheTime = case Args of
+                    [{cursor, undefined}] -> block_time;
+                    _ -> infinity
+                end,
+    ?MK_RESPONSE(get_block_list(Args), CacheTime);
 handle('GET', [<<"height">>], _Req) ->
-    ?MK_RESPONSE(get_block_height());
+    ?MK_RESPONSE(get_block_height(), block_time);
 handle('GET', [<<"hash">>, BlockHash], Req) ->
     Args = ?GET_ARGS([cursor], Req),
-    ?MK_RESPONSE(get_block_by_hash(BlockHash, Args));
+    ?MK_RESPONSE(get_block_by_hash(BlockHash, Args), infinity);
 handle('GET', [BlockId], Req) ->
     Args = ?GET_ARGS([cursor], Req),
     try binary_to_integer(BlockId) of
-        Height -> ?MK_RESPONSE(get_block_by_height(Height, Args))
+        Height -> ?MK_RESPONSE(get_block_by_height(Height, Args), infinity)
     catch _:_ ->
         ?RESPONSE_400
     end;

--- a/src/bh_route_handler.hrl
+++ b/src/bh_route_handler.hrl
@@ -11,7 +11,8 @@
 
 -define(GET_ARGS(A,R), bh_route_handler:get_args((A), (R))).
 
--define(MK_RESPONSE(R), bh_route_handler:mk_response((R))).
+-define(MK_RESPONSE(R), ?MK_RESPONSE(R, undefined)).
+-define(MK_RESPONSE(R,C), bh_route_handler:mk_response((R),(C))).
 -define(INSERT_LAT_LON(L, N, F), bh_route_handler:lat_lon((L), (N), (F))).
 -define(INSERT_LAT_LON(L, F), bh_route_handler:lat_lon((L), (F))).
 -define(CURSOR_ENCODE(M), bh_route_handler:cursor_encode(M)).

--- a/src/bh_route_hotspots.erl
+++ b/src/bh_route_hotspots.erl
@@ -58,9 +58,9 @@ prepare_conn(Conn) ->
 
 handle('GET', [], Req) ->
     Args = ?GET_ARGS([owner, cursor], Req),
-    ?MK_RESPONSE(get_hotspot_list(Args));
+    ?MK_RESPONSE(get_hotspot_list(Args), block_time);
 handle('GET', [Address], _Req) ->
-    ?MK_RESPONSE(get_hotspot(Address));
+    ?MK_RESPONSE(get_hotspot(Address), block_time);
 
 handle(_, _, _Req) ->
     ?RESPONSE_404.

--- a/src/bh_route_pending_txns.erl
+++ b/src/bh_route_pending_txns.erl
@@ -34,13 +34,13 @@ prepare_conn(Conn) ->
       ?S_INSERT_PENDING_TXN => S3}.
 
 handle('GET', [TxnHash], _Req) ->
-    ?MK_RESPONSE(get_pending_txn(TxnHash));
+    ?MK_RESPONSE(get_pending_txn(TxnHash), block_time);
 handle('POST', [], Req) ->
     #{ <<"txn">> := EncodedTxn } = jiffy:decode(elli_request:body(Req), [return_maps]),
     BinTxn = base64:decode(EncodedTxn),
     Txn = txn_unwrap(blockchain_txn_pb:decode_msg(BinTxn, blockchain_txn_pb)),
     Result = insert_pending_txn(Txn, BinTxn),
-    ?MK_RESPONSE(Result);
+    ?MK_RESPONSE(Result, never);
 
 handle(_, _, _Req) ->
     ?RESPONSE_404.

--- a/src/bh_route_txns.erl
+++ b/src/bh_route_txns.erl
@@ -80,7 +80,7 @@ prepare_conn(Conn) ->
      }.
 
 handle('GET', [TxnHash], _Req) ->
-    ?MK_RESPONSE(get_txn(TxnHash));
+    ?MK_RESPONSE(get_txn(TxnHash), infinity);
 
 handle(_, _, _Req) ->
     ?RESPONSE_404.


### PR DESCRIPTION
Add initial cache-control and surrogate control response headers in the simplest form. 

* Infinitely cacheable responses are block pages past the first one and specific transactions
* block_time cacheable responses are all ledger routes (i.e. valid for about a block time)
* never cacheable are individual accounts (since they return the speculative nonce) and newly posted transactions