### PR TITLE
Add hotspot activity route

### DIFF
--- a/src/bh_route_hotspots.erl
+++ b/src/bh_route_hotspots.erl
@@ -61,6 +61,9 @@ handle('GET', [], Req) ->
     ?MK_RESPONSE(get_hotspot_list(Args), block_time);
 handle('GET', [Address], _Req) ->
     ?MK_RESPONSE(get_hotspot(Address), block_time);
+handle('GET', [Address, <<"activity">>], Req) ->
+    Args = ?GET_ARGS([cursor, filter_types], Req),
+    ?MK_RESPONSE(bh_route_txns:get_hotspot_activity_list(Address, Args), block_time);
 
 handle(_, _, _Req) ->
     ?RESPONSE_404.


### PR DESCRIPTION
This adds a `/v1/hotspots/<address>/activity` route for hotspots to get a filtered view of all activity related to a given hotspot. 

This first implementation only filters down rewards_v1 transactions for the given hotspot. 

Note that this PR requires https://github.com/helium/blockchain-etl/commit/07b166d5dbdc1958476cf39de8ee6139ba6d6c7f to be deployed on the target database