### PR TITLE
Moves transaction for a block to a "transactions" route

### DIFF
--- a/src/bh_route_accounts.erl
+++ b/src/bh_route_accounts.erl
@@ -51,7 +51,7 @@ handle('GET', [Account, <<"hotspots">>], Req) ->
     ?MK_RESPONSE(bh_route_hotspots:get_hotspot_list([{owner, Account} | Args]), block_time);
 handle('GET', [Account, <<"activity">>], Req) ->
     Args = ?GET_ARGS([cursor, filter_types], Req),
-    ?MK_RESPONSE(bh_route_txns:get_account_activity_list(Account, Args), block_time);
+    ?MK_RESPONSE(bh_route_txns:get_activity_list({account, Account}, Args), block_time);
 
 handle(_, _, _Req) ->
     ?RESPONSE_404.

--- a/src/bh_route_blocks.erl
+++ b/src/bh_route_blocks.erl
@@ -9,30 +9,19 @@
 %% Utilities
 -export([get_block_height/0,
          get_block_list/1,
-         get_block_by_height/2,
-         get_block_by_hash/2]).
+         get_block/1]).
 
 -define(S_BLOCK_HEIGHT, "block_height").
 
 -define(S_BLOCK_LIST, "block_list").
 -define(S_BLOCK_LIST_BEFORE, "block_list_before").
 
--define(S_BLOCK_BY_HEIGHT, "block_by_height").
--define(S_BLOCK_BY_HEIGHT_BEFORE, "block_by_height_before").
-
 -define(S_BLOCK_BY_HASH, "block_by_hash").
--define(S_BLOCK_BY_HASH_BEFORE, "block_by_hash_before").
+-define(S_BLOCK_BY_HEIGHT, "block_by_height").
 
 -define(SELECT_BLOCK_BASE, "select b.height, b.time, b.block_hash, b.prev_hash, b.transaction_count from blocks b ").
--define(SELECT_BLOCK_TXN_BASE(C),
-        "select * from "
-        "(select b.height, b.time, b.block_hash, b.prev_hash, b.transaction_count, t.hash, t.type, t.fields "
-        "from blocks b left join transactions t on b.height = t.block "
-        "where b." C " = $1 order by t.hash) r "
-       ).
 
 -define(BLOCK_LIST_LIMIT, 100).
--define(BLOCK_TXN_LIST_LIMIT, 50).
 
 prepare_conn(Conn) ->
     {ok, S1} = epgsql:parse(Conn, ?S_BLOCK_HEIGHT,
@@ -49,31 +38,21 @@ prepare_conn(Conn) ->
                             []),
 
     {ok, S4} = epgsql:parse(Conn, ?S_BLOCK_BY_HEIGHT,
-                            [?SELECT_BLOCK_TXN_BASE("height") "limit ", integer_to_list(?BLOCK_TXN_LIST_LIMIT)],
+                            [?SELECT_BLOCK_BASE,
+                            "where b.height = $1"],
                             []),
 
-    {ok, S5} = epgsql:parse(Conn, ?S_BLOCK_BY_HEIGHT_BEFORE,
-                           [?SELECT_BLOCK_TXN_BASE("height"),
-                            "where r.hash > $2 limit ", integer_to_list(?BLOCK_TXN_LIST_LIMIT)],
-                            []),
-
-    {ok, S6} = epgsql:parse(Conn, ?S_BLOCK_BY_HASH,
-                           [?SELECT_BLOCK_TXN_BASE("block_hash"),
-                            "limit ", integer_to_list(?BLOCK_TXN_LIST_LIMIT)],
-                            []),
-
-    {ok, S7} = epgsql:parse(Conn, ?S_BLOCK_BY_HASH_BEFORE,
-                           [?SELECT_BLOCK_TXN_BASE("block_hash"),
-                            "where r.hash > $2 limit ", integer_to_list(?BLOCK_TXN_LIST_LIMIT)],
+    {ok, S5} = epgsql:parse(Conn, ?S_BLOCK_BY_HASH,
+                            [?SELECT_BLOCK_BASE,
+                            "where b.block_hash = $1"],
                             []),
 
     #{?S_BLOCK_HEIGHT => S1,
       ?S_BLOCK_LIST => S2,
       ?S_BLOCK_LIST_BEFORE => S3,
       ?S_BLOCK_BY_HEIGHT => S4,
-      ?S_BLOCK_BY_HEIGHT_BEFORE => S5,
-      ?S_BLOCK_BY_HASH => S6,
-      ?S_BLOCK_BY_HASH_BEFORE => S7}.
+      ?S_BLOCK_BY_HASH => S5
+     }.
 
 
 handle('GET', [], Req) ->
@@ -85,13 +64,21 @@ handle('GET', [], Req) ->
     ?MK_RESPONSE(get_block_list(Args), CacheTime);
 handle('GET', [<<"height">>], _Req) ->
     ?MK_RESPONSE(get_block_height(), block_time);
-handle('GET', [<<"hash">>, BlockHash], Req) ->
+handle('GET', [<<"hash">>, BlockHash], _Req) ->
+    ?MK_RESPONSE(get_block({hash, BlockHash}), infinity);
+handle('GET', [<<"hash">>, BlockHash, <<"transactions">>], Req) ->
     Args = ?GET_ARGS([cursor], Req),
-    ?MK_RESPONSE(get_block_by_hash(BlockHash, Args), infinity);
-handle('GET', [BlockId], Req) ->
+    ?MK_RESPONSE(bh_route_txns:get_block_txn_list({hash, BlockHash}, Args), infinity);
+handle('GET', [BlockId], _Req) ->
+    try binary_to_integer(BlockId) of
+        Height -> ?MK_RESPONSE(get_block({height, Height}), infinity)
+    catch _:_ ->
+        ?RESPONSE_400
+    end;
+handle('GET', [BlockId, <<"transactions">>], Req) ->
     Args = ?GET_ARGS([cursor], Req),
     try binary_to_integer(BlockId) of
-        Height -> ?MK_RESPONSE(get_block_by_height(Height, Args), infinity)
+        Height -> ?MK_RESPONSE(bh_route_txns:get_block_txn_list({height, Height}, Args), infinity)
     catch _:_ ->
         ?RESPONSE_400
     end;
@@ -102,17 +89,17 @@ handle(_Method, _Path, _Req) ->
 
 get_block_list([{cursor, undefined}]) ->
     {ok, _, Results} = ?PREPARED_QUERY(?S_BLOCK_LIST, []),
-    {ok, block_list_to_json(Results), mk_cursor(Results)};
+    {ok, block_list_to_json(Results), mk_block_list_cursor(Results)};
 get_block_list([{cursor, Cursor}]) ->
     case ?CURSOR_DECODE(Cursor) of
         {ok, #{ <<"before">> := Before}} ->
             {ok, _, Results} = ?PREPARED_QUERY(?S_BLOCK_LIST_BEFORE, [Before - (Before rem ?BLOCK_LIST_LIMIT)]),
-            {ok, block_list_to_json(Results), mk_cursor(Results)};
+            {ok, block_list_to_json(Results), mk_block_list_cursor(Results)};
         _ ->
             {error, badarg}
     end.
 
-mk_cursor(Results) when is_list(Results) ->
+mk_block_list_cursor(Results) when is_list(Results) ->
     case length(Results) of
         0 -> undefined;
         _ -> case lists:last(Results) of
@@ -125,54 +112,23 @@ get_block_height() ->
     {ok, _, [{Height}]} = ?PREPARED_QUERY(?S_BLOCK_HEIGHT, []),
     {ok, #{<<"height">> => Height}}.
 
-get_block_by_height(BlockHeight, [{cursor, undefined}]) ->
-    mk_block_txn_list_from_result(?PREPARED_QUERY(?S_BLOCK_BY_HEIGHT, [BlockHeight]));
-get_block_by_height(BlockHeight, [{cursor, Cursor}]) ->
-    case ?CURSOR_DECODE(Cursor) of
-        {ok, #{ <<"hash">> := TxnHash}} ->
-            Results = ?PREPARED_QUERY(?S_BLOCK_BY_HEIGHT_BEFORE, [BlockHeight, TxnHash]),
-            mk_block_txn_list_from_result(Results);
-        _ ->
-            {error, badarg}
-    end.
+get_block({height, Height}) ->
+    Result = ?PREPARED_QUERY(?S_BLOCK_BY_HEIGHT, [Height]),
+    mk_block_from_result(Result);
+get_block({hash, Hash}) ->
+    Result = ?PREPARED_QUERY(?S_BLOCK_BY_HASH, [Hash]),
+    mk_block_from_result(Result).
 
-
-get_block_by_hash(BlockHash, [{cursor, undefined}]) ->
-    Result = ?PREPARED_QUERY(?S_BLOCK_BY_HASH, [BlockHash]),
-    mk_block_txn_list_from_result(Result);
-get_block_by_hash(BlockHash, [{cursor, Cursor}]) ->
-    case ?CURSOR_DECODE(Cursor) of
-        {ok, #{ <<"hash">> := TxnHash}} ->
-            Result = ?PREPARED_QUERY(?S_BLOCK_BY_HASH_BEFORE, [BlockHash, TxnHash]),
-            mk_block_txn_list_from_result(Result);
-        _ ->
-            {error, badarg}
-    end.
-
-mk_block_txn_list_from_result({ok, _, Results}) when Results /= [] ->
-    {ok, block_to_json(Results), mk_block_txn_list_cursor(Results)};
-mk_block_txn_list_from_result(_) ->
+mk_block_from_result({ok, _, [Result]}) ->
+    {ok, block_to_json(Result)};
+mk_block_from_result(_) ->
     {error, not_found}.
 
-mk_block_txn_list_cursor(Results) ->
-    case Results of
-        [{_Height, _Time, _Hash, _PrevHash, _TxnCount, null, _Type, _Fields}] ->
-            undefined;
-        _ when length(Results) < ?BLOCK_TXN_LIST_LIMIT ->
-            undefined;
-        _ ->
-            {_Height, _Time, _Hash, _PrevHash, _TxnCount, TxnHash, _Type, _Fields} = lists:last(Results),
-            #{ hash => TxnHash }
-    end.
-
-%%
-%% json
-%%
 
 block_list_to_json(Results) ->
-    lists:map(fun block_base_to_json/1, Results).
+    lists:map(fun block_to_json/1, Results).
 
-block_base_to_json({Height, Time, Hash, PrevHash, TxnCount}) ->
+block_to_json({Height, Time, Hash, PrevHash, TxnCount}) ->
     #{
       height => Height,
       time => Time,
@@ -180,21 +136,3 @@ block_base_to_json({Height, Time, Hash, PrevHash, TxnCount}) ->
       prev_hash => PrevHash,
       transaction_count => TxnCount
      }.
-
-block_to_json(Results) ->
-    %% Fold all transactions
-    Txns = lists:foldl(fun block_txn_to_json/2, [], Results),
-    %% The left join guarnateees there's always at least one
-    %% transaction in results to pull block information from.
-    {Height, Time, Hash, PrevHash, TxnCount, _TxnHash, _Type, _Fields} = hd(Results),
-    Block = block_base_to_json({Height, Time, Hash, PrevHash, TxnCount}),
-    Block#{
-           transactions => Txns
-           }.
-
-block_txn_to_json({_Height, _Time, _Hash, _PrevHash, _TxnCount, null, _Type, _Fields}, _Acc) ->
-    %% The left join shortcuts out to an empty transaction list if no
-    %% transactions are found.
-    [];
-block_txn_to_json({Height, Time, _Hash, _PrevHash, _TxnCount, TxnHash, Type, Fields}, Acc) ->
-    [bh_route_txns:txn_to_json({Height, Time, TxnHash, Type, Fields}) | Acc].

--- a/src/bh_route_hotspots.erl
+++ b/src/bh_route_hotspots.erl
@@ -63,7 +63,7 @@ handle('GET', [Address], _Req) ->
     ?MK_RESPONSE(get_hotspot(Address), block_time);
 handle('GET', [Address, <<"activity">>], Req) ->
     Args = ?GET_ARGS([cursor, filter_types], Req),
-    ?MK_RESPONSE(bh_route_txns:get_hotspot_activity_list(Address, Args), block_time);
+    ?MK_RESPONSE(bh_route_txns:get_activity_list({hotspot, Address}, Args), block_time);
 
 handle(_, _, _Req) ->
     ?RESPONSE_404.

--- a/src/bh_route_txns.erl
+++ b/src/bh_route_txns.erl
@@ -8,8 +8,8 @@
 -export([prepare_conn/1, handle/3]).
 %% Utilities
 -export([get_txn/1,
-         get_account_activity_list/2,
-         get_hotspot_activity_list/2,
+         get_block_txn_list/2,
+         get_activity_list/2,
          txn_to_json/1,
          txn_list_to_json/1,
          filter_types/1]).
@@ -20,9 +20,13 @@
 -define(S_ACCOUNT_ACTIVITY_LIST_BEFORE, "account_activity_list_before").
 -define(S_HOTSPOT_ACTIVITY_LIST, "hotspot_activity_list").
 -define(S_HOTSPOT_ACTIVITY_LIST_BEFORE, "hotspot_activity_list_before").
+-define(S_BLOCK_HEIGHT_TXN_LIST, "block_height_txn_list").
+-define(S_BLOCK_HEIGHT_TXN_LIST_BEFORE, "block_height_txn_list_before").
+-define(S_BLOCK_HASH_TXN_LIST, "block_hash_txn_list_list").
+-define(S_BLOCK_HASH_TXN_LIST_BEFORE, "block_hash_txn_list_before").
 
 -define(SELECT_TXN_FIELDS(F), ["select t.block, t.time, t.hash, t.type, ", (F), " "]).
--define(SELECT_TXN_BASE, [?SELECT_TXN_FIELDS("t.fields"), "from transactions t "]).
+-define(SELECT_TXN_BASE, ?SELECT_TXN_FIELDS("t.fields")).
 
 -define(SELECT_ACTOR_ACTIVITY_BASE(E),
         [?SELECT_TXN_FIELDS("txn_filter_actor_activity(t.actor, t.type, t.fields) as fields"),
@@ -42,7 +46,14 @@
                                     %% should be in accounts
                                     "and a.actor_role not in ('payer', 'payee', 'owner')")).
 
+-define(SELECT_BLOCK_HEIGHT_TXN_LIST_BASE,
+        [?SELECT_TXN_BASE, "from (select * from transactions where block = $1 order by hash) t "]).
+
+-define(SELECT_BLOCK_HASH_TXN_LIST_BASE,
+        [?SELECT_TXN_BASE, "from (select * from transactions where block = (select height from blocks where block_hash = $1) order by hash) t "]).
+
 -define(ACTOR_ACTIVITY_LIST_LIMIT, 50).
+-define(BLOCK_TXN_LIST_LIMIT, 50).
 
 
 -define(FILTER_TYPES,
@@ -70,10 +81,12 @@
 prepare_conn(Conn) ->
     {ok, S1} = epgsql:parse(Conn, ?S_TXN,
                             [?SELECT_TXN_BASE,
+                             "from transactions t ",
                              "where t.hash = $1"],
                             []),
 
     {ok, S2} = epgsql:parse(Conn, ?S_ACCOUNT_ACTIVITY_LIST,
+
                             [?SELECT_ACCOUNT_ACTIVITY_BASE,
                              "limit ", integer_to_list(?ACTOR_ACTIVITY_LIST_LIMIT)
                             ],
@@ -92,6 +105,7 @@ prepare_conn(Conn) ->
                             ],
                             []),
 
+
     {ok, S5} = epgsql:parse(Conn, ?S_HOTSPOT_ACTIVITY_LIST_BEFORE,
                             [?SELECT_HOTSPOT_ACTIVITY_BASE,
                              "where (t.block = $3 and t.hash > $4) or t.block < $3 ",
@@ -99,11 +113,43 @@ prepare_conn(Conn) ->
                             ],
                             []),
 
+    {ok, S6} = epgsql:parse(Conn, ?S_BLOCK_HEIGHT_TXN_LIST,
+                            [?SELECT_BLOCK_HEIGHT_TXN_LIST_BASE,
+                             "limit ", integer_to_list(?BLOCK_TXN_LIST_LIMIT)
+                            ],
+                            []),
+
+    {ok, S7} = epgsql:parse(Conn, ?S_BLOCK_HEIGHT_TXN_LIST_BEFORE,
+                            [?SELECT_BLOCK_HEIGHT_TXN_LIST_BASE,
+                             "where t.hash > $2",
+                             "limit ", integer_to_list(?BLOCK_TXN_LIST_LIMIT)
+                            ],
+                            []),
+
+    {ok, S8} = epgsql:parse(Conn, ?S_BLOCK_HASH_TXN_LIST,
+                            [?SELECT_BLOCK_HASH_TXN_LIST_BASE,
+                             "limit ", integer_to_list(?BLOCK_TXN_LIST_LIMIT)
+                            ],
+                            []),
+
+    {ok, S9} = epgsql:parse(Conn, ?S_BLOCK_HASH_TXN_LIST_BEFORE,
+                            [?SELECT_BLOCK_HASH_TXN_LIST_BASE,
+                             "where t.hash > $2",
+                             "limit ", integer_to_list(?BLOCK_TXN_LIST_LIMIT)
+                            ],
+                            []),
+
+
+
     #{?S_TXN => S1,
       ?S_ACCOUNT_ACTIVITY_LIST => S2,
       ?S_ACCOUNT_ACTIVITY_LIST_BEFORE => S3,
       ?S_HOTSPOT_ACTIVITY_LIST => S4,
-      ?S_HOTSPOT_ACTIVITY_LIST_BEFORE => S5
+      ?S_HOTSPOT_ACTIVITY_LIST_BEFORE => S5,
+      ?S_BLOCK_HEIGHT_TXN_LIST => S6,
+      ?S_BLOCK_HEIGHT_TXN_LIST_BEFORE => S7,
+      ?S_BLOCK_HASH_TXN_LIST => S8,
+      ?S_BLOCK_HASH_TXN_LIST_BEFORE => S9
      }.
 
 handle('GET', [TxnHash], _Req) ->
@@ -122,18 +168,45 @@ get_txn(Key) ->
     end.
 
 
-%%
-%% Account Activity
-%%
-
-get_account_activity_list(Account, Args) ->
-    get_activity_list(Account, {?S_ACCOUNT_ACTIVITY_LIST, ?S_ACCOUNT_ACTIVITY_LIST_BEFORE}, Args).
 
 %%
-%% Hotspot Activity
+%% Block Transctions
 %%
 
-get_hotspot_activity_list(Address, Args) ->
+get_block_txn_list({height, Height}, Args) ->
+    get_block_txn_list(Height, {?S_BLOCK_HEIGHT_TXN_LIST, ?S_BLOCK_HEIGHT_TXN_LIST_BEFORE}, Args);
+get_block_txn_list({hash, Hash}, Args) ->
+    get_block_txn_list(Hash, {?S_BLOCK_HASH_TXN_LIST, ?S_BLOCK_HASH_TXN_LIST_BEFORE}, Args).
+
+get_block_txn_list(Block, {StartQuery, _CursorQuery}, [{cursor, undefined}]) ->
+    Result = ?PREPARED_QUERY(StartQuery, [Block]),
+    mk_txn_list_from_result(Result);
+get_block_txn_list(Block, {_StartQuery, CursorQuery}, [{cursor, Cursor}]) ->
+    case ?CURSOR_DECODE(Cursor) of
+        {ok, #{ <<"hash">> := Hash }} ->
+            Result = ?PREPARED_QUERY(CursorQuery, [Block, Hash]),
+            mk_txn_list_from_result(Result)
+    end.
+
+mk_txn_list_from_result({ok, _, Results}) ->
+    {ok, txn_list_to_json(Results), mk_txn_list_cursor(Results)}.
+
+mk_txn_list_cursor(Results) ->
+    case length(Results) < ?BLOCK_TXN_LIST_LIMIT of
+        true -> undefined;
+        false ->
+            {_Height, _Time, Hash, _Type, _Fields} = lists:last(Results),
+            #{ hash => Hash}
+    end.
+
+
+%%
+%% Activity
+%%
+
+get_activity_list({account, Account}, Args) ->
+    get_activity_list(Account, {?S_ACCOUNT_ACTIVITY_LIST, ?S_ACCOUNT_ACTIVITY_LIST_BEFORE}, Args);
+get_activity_list({hotspot, Address}, Args) ->
     get_activity_list(Address, {?S_HOTSPOT_ACTIVITY_LIST, ?S_HOTSPOT_ACTIVITY_LIST_BEFORE}, Args).
 
 

--- a/test/bh_route_blocks_SUITE.erl
+++ b/test/bh_route_blocks_SUITE.erl
@@ -4,7 +4,11 @@
 -include("ct_utils.hrl").
 
 all() -> [
-          height_test
+          height_test,
+          block_for_height_test,
+          block_for_height_txns_test,
+          block_for_hash_test,
+          block_for_hash_txns_test
          ].
 
 init_per_suite(Config) ->
@@ -18,3 +22,27 @@ height_test(_Config) ->
     ?assertMatch(#{ <<"data">> := #{ <<"height">> :=  _}}, Json),
 
     ok.
+
+block_for_height_test(_Config) ->
+    {ok, {_, _, Json}} = ?json_request("/v1/blocks/1"),
+    ?assertMatch(#{ <<"data">> :=
+                        #{ <<"height">> :=  1,
+                           <<"transaction_count">> := 70
+                         }}, Json).
+
+block_for_height_txns_test(_Config) ->
+    {ok, {_, _, Json}} = ?json_request("/v1/blocks/1/transactions"),
+    #{ <<"data">> := Txns, <<"cursor">> := _ } = Json,
+    ?assertEqual(50, length(Txns)).
+
+block_for_hash_test(_Config) ->
+    {ok, {_, _, Json}} = ?json_request("/v1/blocks/hash/La6PuV80Ps9qTP0339Pwm64q3_deMTkv6JOo1251EJI"),
+    ?assertMatch(#{ <<"data">> :=
+                        #{ <<"height">> :=  1,
+                           <<"transaction_count">> := 70
+                         }}, Json).
+
+block_for_hash_txns_test(_Config) ->
+    {ok, {_, _, Json}} = ?json_request("/v1/blocks/hash/La6PuV80Ps9qTP0339Pwm64q3_deMTkv6JOo1251EJI/transactions"),
+    #{ <<"data">> := Txns, <<"cursor">> := _ } = Json,
+    ?assertEqual(50, length(Txns)).


### PR DESCRIPTION
This PR:

* **Removes** the `transactions` field from `v1/blocks/:height` and `v1/blocks/hash/:hash`. These routes just return the top level block descriptor but is no longer paged since there are no longer any transactions being returned. 
* **Adds** transaction list routes to retrieve paged responses for transactions for a block based on either height or hash. The new routes are:`v1/blocks/:height/transactions` and `v1/blocks/hash/:hash/transactions` 