### PR TITLE
add election routes

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -21,6 +21,7 @@
      bh_route_accounts,
      bh_route_hotspots,
      bh_route_txns,
+     bh_route_elections,
      bh_route_pending_txns
     ]},
    {db_rw_handlers,

--- a/src/bh_route_accounts.erl
+++ b/src/bh_route_accounts.erl
@@ -52,6 +52,9 @@ handle('GET', [Account, <<"hotspots">>], Req) ->
 handle('GET', [Account, <<"activity">>], Req) ->
     Args = ?GET_ARGS([cursor, filter_types], Req),
     ?MK_RESPONSE(bh_route_txns:get_activity_list({account, Account}, Args), block_time);
+handle('GET', [Account, <<"elections">>], Req) ->
+    Args = ?GET_ARGS([cursor], Req),
+    ?MK_RESPONSE(bh_route_elections:get_election_list({account, Account}, Args), block_time);
 
 handle(_, _, _Req) ->
     ?RESPONSE_404.

--- a/src/bh_route_elections.erl
+++ b/src/bh_route_elections.erl
@@ -1,0 +1,122 @@
+-module(bh_route_elections).
+
+-export([prepare_conn/1, handle/3]).
+-export([get_election_list/2]).
+
+-behavior(bh_route_handler).
+-behavior(bh_db_worker).
+
+-include("bh_route_handler.hrl").
+
+-define(S_ELECTION_TXN_LIST, "election_txn_list").
+-define(S_ELECTION_TXN_LIST_BEFORE, "election_txn_list_before").
+-define(S_ELECTION_ACTOR_TXN_LIST, "election_actor_txn_list").
+-define(S_ELECTION_ACTOR_TXN_LIST_BEFORE, "election_actor_txn_list_before").
+-define(S_ELECTION_ACCOUNT_TXN_LIST, "election_account_txn_list").
+-define(S_ELECTION_ACCOUNT_TXN_LIST_BEFORE, "election_account_txn_list_before").
+
+-define(SELECT_ELECTION_TXN_LIST_BASE,
+       [?SELECT_TXN_FIELDS("txn_filter_actor_activity(t.actor, t.type, t.fields) as fields"),
+        "from ",
+        "(select tr.*,'undefined' as actor from transactions tr where type = 'consensus_group_v1' order by block desc) t "]).
+
+-define(SELECT_ELECTION_ACTOR_TXN_LIST_BASE,
+       [?SELECT_TXN_FIELDS("txn_filter_actor_activity(t.actor, t.type, t.fields) as fields"),
+        "from ",
+        "(select tr.*, a.actor from",
+        " transaction_actors a inner join transactions tr on a.transaction_hash = tr.hash",
+        " where tr.type = 'consensus_group_v1' and a.actor=$1 order by block desc) t "]).
+
+-define(SELECT_ELECTION_ACCOUNT_TXN_LIST_BASE,
+       [?SELECT_TXN_FIELDS("txn_filter_actor_activity(t.actor, t.type, t.fields) as fields"),
+        "from ",
+        "(select tr.*, a.actor from",
+        " transaction_actors a inner join transactions tr on a.transaction_hash = tr.hash",
+        " where tr.type = 'consensus_group_v1' and a.actor in",
+        " (select address from gateway_ledger where owner = $1) ",
+        "order by block desc) t "]).
+
+prepare_conn(Conn) ->
+    {ok, S1} = epgsql:parse(Conn, ?S_ELECTION_TXN_LIST,
+                            [?SELECT_ELECTION_TXN_LIST_BASE,
+                             "limit ", integer_to_list(?ELECTION_TXN_LIST_LIMIT)
+                            ],
+                             []),
+
+    {ok, S2} = epgsql:parse(Conn, ?S_ELECTION_TXN_LIST_BEFORE,
+                            [?SELECT_ELECTION_TXN_LIST_BASE,
+                             "where t.block < $1",
+                             "limit ", integer_to_list(?ELECTION_TXN_LIST_LIMIT)
+                            ],
+                            []),
+
+    {ok, S3} = epgsql:parse(Conn, ?S_ELECTION_ACTOR_TXN_LIST,
+                            [?SELECT_ELECTION_ACTOR_TXN_LIST_BASE,
+                             "limit ", integer_to_list(?ELECTION_TXN_LIST_LIMIT)
+                            ],
+                             []),
+
+    {ok, S4} = epgsql:parse(Conn, ?S_ELECTION_ACTOR_TXN_LIST_BEFORE,
+                            [?SELECT_ELECTION_ACTOR_TXN_LIST_BASE,
+                             "where t.block < $2",
+                             "limit ", integer_to_list(?ELECTION_TXN_LIST_LIMIT)
+                            ],
+                            []),
+
+    {ok, S5} = epgsql:parse(Conn, ?S_ELECTION_ACCOUNT_TXN_LIST,
+                            [?SELECT_ELECTION_ACCOUNT_TXN_LIST_BASE,
+                             "limit ", integer_to_list(?ELECTION_TXN_LIST_LIMIT)
+                            ],
+                             []),
+
+    {ok, S6} = epgsql:parse(Conn, ?S_ELECTION_ACCOUNT_TXN_LIST_BEFORE,
+                            [?SELECT_ELECTION_ACCOUNT_TXN_LIST_BASE,
+                             "where t.block < $2",
+                             "limit ", integer_to_list(?ELECTION_TXN_LIST_LIMIT)
+                            ],
+                            []),
+
+    #{
+      ?S_ELECTION_TXN_LIST => S1,
+      ?S_ELECTION_TXN_LIST_BEFORE => S2,
+      ?S_ELECTION_ACTOR_TXN_LIST => S3,
+      ?S_ELECTION_ACTOR_TXN_LIST_BEFORE => S4,
+      ?S_ELECTION_ACCOUNT_TXN_LIST => S5,
+      ?S_ELECTION_ACCOUNT_TXN_LIST_BEFORE => S6
+     }.
+
+
+handle('GET', [], Req) ->
+    Args = ?GET_ARGS([cursor], Req),
+    ?MK_RESPONSE(get_election_list(undefined, Args), block_time).
+
+
+get_election_list({hotspot, Address}, Args) ->
+    get_election_list([Address], {?S_ELECTION_ACTOR_TXN_LIST, ?S_ELECTION_ACTOR_TXN_LIST_BEFORE}, Args);
+get_election_list({account, Address}, Args) ->
+    get_election_list([Address], {?S_ELECTION_ACCOUNT_TXN_LIST, ?S_ELECTION_ACCOUNT_TXN_LIST_BEFORE}, Args);
+get_election_list(undefined, Args) ->
+    get_election_list([], {?S_ELECTION_TXN_LIST, ?S_ELECTION_TXN_LIST_BEFORE}, Args).
+
+get_election_list(_, {StartQuery, _CursorQuery}, [{cursor, undefined}]) ->
+    Result = ?PREPARED_QUERY(StartQuery, []),
+    mk_election_list_from_result(Result);
+get_election_list(Args, {_StartQuery, CursorQuery}, [{cursor, Cursor}]) ->
+    case ?CURSOR_DECODE(Cursor) of
+        {ok, #{ <<"before">> := Block }} ->
+            Result = ?PREPARED_QUERY(CursorQuery, Args ++ [Block]),
+            mk_election_list_from_result(Result);
+        _ ->
+            {error, badarg}
+    end.
+
+mk_election_list_from_result({ok, _, Results}) ->
+    {ok, ?TXN_LIST_TO_JSON(Results), mk_election_list_cursor(Results)}.
+
+mk_election_list_cursor(Results) ->
+    case length(Results) < ?ELECTION_TXN_LIST_LIMIT of
+        true -> undefined;
+        false ->
+            {Height, _Time, _Hash, _Type, _Fields} = lists:last(Results),
+            #{ before => Height}
+    end.

--- a/src/bh_route_handler.hrl
+++ b/src/bh_route_handler.hrl
@@ -20,3 +20,11 @@
 
 -define (BIN_TO_B64(B), base64url:encode((B))).
 -define (BIN_TO_B58(B), list_to_binary(libp2p_crypto:bin_to_b58((B)))).
+
+-define(SELECT_TXN_FIELDS(F), ["select t.block, t.time, t.hash, t.type, ", (F), " "]).
+-define(SELECT_TXN_BASE, ?SELECT_TXN_FIELDS("t.fields")).
+-define(TXN_LIST_TO_JSON(R), bh_route_txns:txn_list_to_json((R))).
+
+-define(BLOCK_LIST_LIMIT, 100).
+-define(BLOCK_TXN_LIST_LIMIT, 50).
+-define(ELECTION_TXN_LIST_LIMIT, 50).

--- a/src/bh_route_hotspots.erl
+++ b/src/bh_route_hotspots.erl
@@ -64,6 +64,9 @@ handle('GET', [Address], _Req) ->
 handle('GET', [Address, <<"activity">>], Req) ->
     Args = ?GET_ARGS([cursor, filter_types], Req),
     ?MK_RESPONSE(bh_route_txns:get_activity_list({hotspot, Address}, Args), block_time);
+handle('GET', [Address, <<"elections">>], Req) ->
+    Args = ?GET_ARGS([cursor_types], Req),
+    ?MK_RESPONSE(bh_route_elections:get_election_list({hotspot, Address}, Args), block_time);
 
 handle(_, _, _Req) ->
     ?RESPONSE_404.

--- a/src/bh_routes.erl
+++ b/src/bh_routes.erl
@@ -21,6 +21,8 @@ handle(Method, [<<"v1">>, <<"transactions">> | Tail], Req) ->
     bh_route_txns:handle(Method, Tail, Req);
 handle(Method, [<<"v1">>, <<"pending_transactions">> | Tail], Req) ->
     bh_route_pending_txns:handle(Method, Tail, Req);
+handle(Method, [<<"v1">>, <<"elections">> | Tail], Req) ->
+    bh_route_elections:handle(Method, Tail, Req);
 handle('GET', [], _Req) ->
     {200, [], <<>>};
 

--- a/test/bh_route_elections_SUITE.erl
+++ b/test/bh_route_elections_SUITE.erl
@@ -1,0 +1,34 @@
+-module(bh_route_elections_SUITE).
+-compile([nowarn_export_all, export_all]).
+
+-include("ct_utils.hrl").
+-include("../src/bh_route_handler.hrl").
+
+all() -> [
+          election_list_test
+         ].
+
+init_per_suite(Config) ->
+    ?init_bh(Config).
+
+end_per_suite(Config) ->
+    ?end_bh(Config).
+
+election_list_test(_Config) ->
+    {ok, {_, _, FirstJson}} = ?json_request("/v1/elections"),
+    #{ <<"data">> := FirstTxns, <<"cursor">> := Cursor } = FirstJson,
+    ?assert(length(FirstTxns) =< ?ELECTION_TXN_LIST_LIMIT),
+
+    {ok, {_, _, NextJson}} = ?json_request("/v1/elections?cursor=" ++ Cursor),
+    #{ <<"data">> := NextTxns, <<"cursor">> := _ } = NextJson,
+    ?assertEqual(?ELECTION_TXN_LIST_LIMIT, length(NextTxns)).
+
+hotspot_election_list_test(_Config) ->
+    {ok, {_, _, Json}} = ?json_request("/v1/hotspots/1182nyT3oXZPMztMSww4mzaaQXGXd5T7JwDfEth6obSCwwxxfsB/elections"),
+    #{ <<"data">> := Txns } = Json,
+    ?assert(length(Txns) > 0).
+
+account_election_list_test(_Config) ->
+    {ok, {_, _, Json}} = ?json_request("/v1/accounts/13GCcF7oGb6waFBzYDMmydmXx4vNDUZGX4LE3QUh8eSBG53s5bx/elections"),
+    #{ <<"data">> := Txns } = Json,
+    ?assert(length(Txns) > 0).


### PR DESCRIPTION
This adds:

* `/v1/elections` for a paged list of consensus group transactions
* `/v1/hotspots/:address/elections` for a paged list of consensus groups that a given hotspot was involved in 
* `/v1/accounts/:address/elections` for a paged list of consensus groups that all hotspots for a given account were  involved in 