### PR TITLE
Fix account hotspot lists with cursor

### DIFF
--- a/test/bh_route_accounts_SUITE.erl
+++ b/test/bh_route_accounts_SUITE.erl
@@ -91,8 +91,14 @@ activity_filter_no_result_test(_Config) ->
 
 
 hotspots_test(_Config) ->
-    {ok, {_, _, Json}} = ?json_request("/v1/accounts/13GCcF7oGb6waFBzYDMmydmXx4vNDUZGX4LE3QUh8eSBG53s5bx/hotspots"),
-    #{ <<"data">> := Data } = Json,
+    Account = "13YuCz3mZ55HZ6hJJvQHCZXGgE8ooe2CSvbtSHQR3m5vZ1EVCNZ",
+    {ok, {_, _, Json}} = ?json_request(["/v1/accounts/", Account, "/hotspots"]),
+    #{ <<"data">> := Data,
+       <<"cursor">> := Cursor } = Json,
     ?assert(length(Data) > 0),
+
+    {ok, {_, _, NextJson}} = ?json_request(["/v1/accounts/", Account, "/hotspots?cursor=", Cursor]),
+    #{ <<"data">> := NextData } = NextJson,
+    ?assert(length(NextData) >= 0),
 
     ok.


### PR DESCRIPTION
This fixes the `/v1/accounts/:address/hotspots` endpoint for accounts with more than 100 hotspots. 