### PR TITLE
Migrate to inventory tables

### DIFF
--- a/src/bh_route_accounts.erl
+++ b/src/bh_route_accounts.erl
@@ -14,7 +14,7 @@
 -define(S_ACCOUNT_LIST, "account_list").
 -define(S_ACCOUNT, "account").
 
--define(SELECT_ACCOUNT_BASE(A), "select (select max(height) from blocks) as height, l.address, l.dc_balance, l.dc_nonce, l.security_balance, l.security_nonce, l.balance, l.nonce, l.first_block" A " from account_ledger l ").
+-define(SELECT_ACCOUNT_BASE(A), "select (select max(height) from blocks) as height, l.address, l.dc_balance, l.dc_nonce, l.security_balance, l.security_nonce, l.balance, l.nonce, l.first_block" A " from account_inventory l ").
 -define(SELECT_ACCOUNT_BASE, ?SELECT_ACCOUNT_BASE("")).
 
 -define(ACCOUNT_LIST_LIMIT, 100).

--- a/src/bh_route_hotspots.erl
+++ b/src/bh_route_hotspots.erl
@@ -18,10 +18,12 @@
 -define(S_HOTSPOT, "hotspot").
 
 -define(SELECT_HOTSPOT_BASE(G),
-        ["select (select max(height) from blocks) as height, g.block, g.first_block, g.address, g.owner, g.location, g.score, ",
-        "g.short_street, g.long_street, g.short_city, g.long_city, g.short_state, g.long_state, g.short_country, g.long_country ", G, " "]).
--define(SELECT_HOTSPOT_BASE, ?SELECT_HOTSPOT_BASE("from gateway_ledger g")).
--define(SELECT_OWNER_HOTSPOT, ?SELECT_HOTSPOT_BASE("from (select * from gateway_ledger where owner = $1 order by first_block desc, address) as g")).
+        ["select (select max(height) from blocks) as height, g.last_block, g.first_block, g.address, g.owner, g.location, g.score, ",
+         "l.short_street, l.long_street, l.short_city, l.long_city, l.short_state, l.long_state, l.short_country, l.long_country ",
+         G, " inner join locations l on g.location = l.location "
+        ]).
+-define(SELECT_HOTSPOT_BASE, ?SELECT_HOTSPOT_BASE("from gateway_inventory g")).
+-define(SELECT_OWNER_HOTSPOT, ?SELECT_HOTSPOT_BASE("from (select * from gateway_inventory where owner = $1 order by first_block desc, address) as g")).
 
 -define(HOTSPOT_LIST_LIMIT, 100).
 

--- a/src/bh_route_stats.erl
+++ b/src/bh_route_stats.erl
@@ -75,7 +75,7 @@ prepare_conn(Conn) ->
                             ], []),
 
     {ok, S3} = epgsql:parse(Conn, ?S_TOKEN_SUPPLY,
-                            "select (sum(balance) / 100000000) as token_supply from account_ledger",
+                            "select (sum(balance) / 100000000) as token_supply from account_inventory",
                             []),
 
     #{

--- a/src/bh_route_txns.erl
+++ b/src/bh_route_txns.erl
@@ -45,7 +45,7 @@
          "from (select tr.*, a.actor ",
          "from transaction_actors a inner join transactions tr on a.transaction_hash = tr.hash ",
          " where a.block >= $3 and a.block < $4",
-         " and a.actor in (select address from gateway_ledger where owner = $1) ", (E),
+         " and a.actor in (select address from gateway_inventory where owner = $1) ", (E),
          " and tr.type = ANY($2) order by tr.block desc) as t "
         ]).
 


### PR DESCRIPTION
Since the defintion of the gateway ledger was changed the
ledger/inventory name change would not have made this switch any
better.

A short outage will occur while upgrading etl and the http front ends.