### PR TITLE
Madninja/hotspot city search

### DIFF
--- a/src/bh_route_accounts.erl
+++ b/src/bh_route_accounts.erl
@@ -79,7 +79,7 @@ handle('GET', [Account], _Req) ->
     ?MK_RESPONSE(get_account(Account), never);
 handle('GET', [Account, <<"hotspots">>], Req) ->
     Args = ?GET_ARGS([cursor], Req),
-    ?MK_RESPONSE(bh_route_hotspots:get_hotspot_list([{owner, Account} | Args]), block_time);
+    ?MK_RESPONSE(bh_route_hotspots:get_hotspot_list([{owner, Account}, {city, undefined} | Args]), block_time);
 handle('GET', [Account, <<"activity">>], Req) ->
     Args = ?GET_ARGS([cursor, filter_types], Req),
     Result = bh_route_txns:get_activity_list({account, Account}, Args),

--- a/test/bh_route_hotspots_SUITE.erl
+++ b/test/bh_route_hotspots_SUITE.erl
@@ -14,7 +14,10 @@ all() -> [
           activity_low_block_test,
           activity_filter_no_result_test,
           elections_test,
-          challenges_test
+          challenges_test,
+          list_city_test,
+          list_city_search_test,
+          city_list_test
          ].
 
 init_per_suite(Config) ->
@@ -114,4 +117,37 @@ challenges_test(_Config) ->
     #{ <<"data">> := NextData } = NextJson,
     ?assert(length(NextData) >= 0),
 
+    ok.
+
+list_city_test(_Config) ->
+    {ok, {_, _, Json}} = ?json_request(["/v1/hotspots/cities"]),
+    #{ <<"data">> := Data,
+       <<"cursor">> := Cursor } = Json,
+    ?assert(length(Data) >= 0),
+
+    {ok, {_, _, NextJson}} = ?json_request(["/v1/hotspots/cities?cursor=", Cursor]),
+    #{ <<"data">> := NextData } = NextJson,
+    ?assert(length(NextData) >= 0),
+    ok.
+
+list_city_search_test(_Config) ->
+    {ok, {_, _, Json}} = ?json_request(["/v1/hotspots/cities?search=s"]),
+    #{ <<"data">> := Data,
+       <<"cursor">> := Cursor } = Json,
+    ?assert(length(Data) >= 0),
+
+    {ok, {_, _, NextJson}} = ?json_request(["/v1/hotspots/cities?cursor=", Cursor]),
+    #{ <<"data">> := NextData } = NextJson,
+    ?assert(length(NextData) >= 0),
+    ok.
+
+city_list_test(_Config) ->
+    {ok, {_, _, Json}} = ?json_request(["/v1/hotspots/cities/San%20Francisco"]),
+    #{ <<"data">> := Data,
+       <<"cursor">> := Cursor } = Json,
+    ?assert(length(Data) >= 0),
+
+    {ok, {_, _, NextJson}} = ?json_request(["/v1/hotspots/cities/San%20Francisco?cursor=", Cursor]),
+    #{ <<"data">> := NextData } = NextJson,
+    ?assert(length(NextData) >= 0),
     ok.

--- a/test/bh_route_snapshots_SUITE.erl
+++ b/test/bh_route_snapshots_SUITE.erl
@@ -24,8 +24,7 @@ list_test(_Config) ->
     ?assert(length(FirstTxns) =< ?SNAPSHOT_LIST_LIMIT),
 
     {ok, {_, _, NextJson}} = ?json_request(["/v1/snapshots?cursor=", Cursor]),
-    #{ <<"data">> := NextTxns,
-       <<"cursor">> := _
+    #{ <<"data">> := NextTxns
      } = NextJson,
     ?assert(length(NextTxns) =< ?SNAPSHOT_LIST_LIMIT).
 


### PR DESCRIPTION
Since hotspots are usually deployed in city like clusters applications like to show city counts and list hotspots by city. This PR offers:

*  `/v1/hotspots/cities` to list all known hotspots cities with a count for each city. This route supports a `search` parameter that filters down the city list by it's `long_city` name. 
* `/v1/hotspots/cities/:city` to list hotspots for a specific city. Note that the `:city` URL parameter has to be the the exact `long_city` result from one of the city list entries (case sensitive) and needs to be uri encoded