### PR TITLE
Madninja/search city fix

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -27,7 +27,8 @@
      bh_route_stats,
      bh_route_oracle,
      bh_route_vars,
-     bh_route_snapshots
+     bh_route_snapshots,
+     bh_route_cities
     ]},
    {db_rw_handlers,
     [

--- a/src/bh_route_cities.erl
+++ b/src/bh_route_cities.erl
@@ -1,0 +1,181 @@
+-module(bh_route_cities).
+
+-behavior(bh_route_handler).
+-behavior(bh_db_worker).
+
+-include("bh_route_handler.hrl").
+
+-export([prepare_conn/1, handle/3]).
+%% Utilities
+-export([get_city_list/1]).
+
+
+-define(S_CITY_LIST, "city_list").
+-define(S_CITY_LIST_BEFORE, "city_list_before").
+-define(S_CITY_SEARCH, "city_search").
+-define(S_CITY_SEARCH_BEFORE, "city_search_before").
+-define(S_CITY_HOTSPOT_LIST, "hotspot_city_list").
+-define(S_CITY_HOTSPOT_LIST_BEFORE, "hotspor_city_list_before").
+
+
+-define(SELECT_CITY_LIST_BASE,
+        ["select ",
+         "  short_city, long_city, ",
+         "  short_state, long_state, ",
+         "  short_country, long_country, ",
+         "  city_id, rank, hotspot_count ",
+         "from ",
+         "  (select",
+         "     last(l.short_city) as short_city, l.long_city, ",
+         "     last(l.short_state) as short_state, l.long_state, ",
+         "     last(l.short_country) as short_country, l.long_country, ",
+         "     coalesce(l.long_city, '') || coalesce(l.long_state, '') || coalesce(l.long_country, '') as city_id, "
+         "     count(*) as hotspot_count, ",
+         "     1 as rank ",
+         "   from locations l inner join gateway_inventory g on g.location = l.location "
+         "   group by (l.long_country, l.long_state, l.long_city) ",
+         "   order by city_id ",
+         "   ) c "
+        ]
+       ).
+
+-define(SELECT_CITY_SEARCH_BASE,
+        ["select ",
+         "  short_city, long_city, ",
+         "  short_state, long_state, ",
+         "  short_country, long_country, ",
+         "  city_id, rank, hotspot_count ",
+         "from ",
+         "  (select",
+         "     last(l.short_city) as short_city, l.long_city, ",
+         "     last(l.short_state) as short_state, l.long_state, ",
+         "     last(l.short_country) as short_country, l.long_country, ",
+         "     coalesce(l.long_city, '') || coalesce(l.long_state, '') || coalesce(l.long_country, '') as city_id, "
+         "     count(*) as hotspot_count, ",
+         "     word_similarity(l.long_city, $1) as rank ",
+         "   from locations l inner join gateway_inventory g on g.location = l.location "
+         "   where l.search_city %> lower($1) ",
+         "   group by (l.long_country, l.long_state, l.long_city) ",
+         "   order by rank desc, city_id ",
+         "   ) c "
+        ]
+       ).
+
+-define(CITY_LIST_LIMIT, 100).
+
+prepare_conn(Conn) ->
+    {ok, S1} = epgsql:parse(Conn, ?S_CITY_SEARCH,
+                            ?SELECT_CITY_SEARCH_BASE
+                           , []),
+
+    {ok, S2} = epgsql:parse(Conn, ?S_CITY_SEARCH_BEFORE,
+                            [?SELECT_CITY_SEARCH_BASE,
+                             "where rank <= $2 and city_id > $3 ",
+                             "limit ", integer_to_list(?CITY_LIST_LIMIT)
+                           ], []),
+
+    {ok, S3} = epgsql:parse(Conn, ?S_CITY_LIST,
+                            [?SELECT_CITY_LIST_BASE,
+                             "limit ", integer_to_list(?CITY_LIST_LIMIT)
+                            ],[]),
+
+    {ok, S4} = epgsql:parse(Conn, ?S_CITY_LIST_BEFORE,
+                            [?SELECT_CITY_LIST_BASE,
+                             "where rank <= $1 and city_id > $2 ",
+                             "limit ", integer_to_list(?CITY_LIST_LIMIT)
+                            ] , []),
+
+    #{
+      ?S_CITY_SEARCH => S1,
+      ?S_CITY_SEARCH_BEFORE => S2,
+      ?S_CITY_LIST => S3,
+      ?S_CITY_LIST_BEFORE => S4
+     }.
+
+
+handle('GET', [], Req) ->
+    Args = ?GET_ARGS([search, cursor], Req),
+    Result = get_city_list(Args),
+    ?MK_RESPONSE(Result, block_time);
+%% handle('GET', [City, <<"hotspots">>], Req) ->
+%%     Args = ?GET_ARGS([cursor], Req),
+%%     Result = get_hotspot_list([{owner, undefined}, {city, City} | Args]),
+%%     ?MK_RESPONSE(Result, block_time);
+
+handle(_, _, _Req) ->
+    ?RESPONSE_404.
+
+
+get_city_list([{search, undefined}, {cursor, undefined}]) ->
+    Result = ?PREPARED_QUERY(?S_CITY_LIST, []),
+    mk_city_list_from_result(undefined, Result);
+get_city_list([{search, Search}, {cursor, undefined}]) ->
+    Result = ?PREPARED_QUERY(?S_CITY_SEARCH, [Search]),
+    mk_city_list_from_result(undefined, Result);
+get_city_list([{search, _Search}, {cursor, Cursor}]) ->
+    case ?CURSOR_DECODE(Cursor) of
+        {ok, #{<<"city_id">> := CityId,
+               <<"rank">> := Rank
+              }=C} ->
+            Search = maps:get(<<"search">>, C, undefined),
+            Result = case Search of
+                         undefined ->
+                             ?PREPARED_QUERY(?S_CITY_LIST_BEFORE, [Rank, CityId]);
+                         Search ->
+                             ?PREPARED_QUERY(?S_CITY_SEARCH_BEFORE, [Search, Rank, CityId])
+                     end,
+            mk_city_list_from_result(Search, Result);
+        _ ->
+            {error, badarg}
+    end.
+
+
+mk_city_list_from_result(Search, {ok, _, Results}) ->
+    {ok, city_list_to_json(Results), mk_city_list_cursor(Search, Results)}.
+
+mk_city_list_cursor(Search, Results) when is_list(Results) ->
+    case length(Results) < ?CITY_LIST_LIMIT of
+        true ->
+            undefined;
+        false ->
+            {_ShortCity, _LongCity,
+             _ShortState, _LongState,
+             _ShortCountry, _LongCountry,
+             CityId, Rank, _Count} = lists:last(Results),
+            Base = #{
+                     city_id => CityId,
+                     rank => Rank
+                    },
+            case Search of
+                undefined -> Base;
+                _ -> Base#{ search => Search }
+            end
+    end.
+
+%%
+%% to_jaon
+%%
+
+city_list_to_json(Results) ->
+    lists:map(fun city_to_json/1, Results).
+
+
+city_to_json({ShortCity, LongCity,
+              ShortState, LongState,
+              ShortCountry, LongCountry,
+              _CityId, _Rank, Count}) ->
+    Base = bh_route_hotspots:to_geo_json({ShortCity, LongCity,
+                                          ShortState, LongState,
+                                          ShortCountry, LongCountry}),
+    Base#{ hotspot_count => Count,
+           city_id => city_to_b64([LongCountry, LongState, LongCity])
+         }.
+
+city_to_b64(CityFields) ->
+    Fields = lists:map(fun(null) -> <<>>;
+                          (F) -> F
+                       end, CityFields),
+    ?BIN_TO_B64(<< <<(byte_size(Key)):8/integer, Key/binary>> || Key <- Fields >>).
+
+%% bin_to_city(Data) ->
+%%     [ Key || << Len:8/unsigned-integer, Key:Len/binary >> <= Data ].

--- a/src/bh_route_hotspots.erl
+++ b/src/bh_route_hotspots.erl
@@ -9,7 +9,7 @@
 %% Utilities
 -export([get_hotspot_list/1,
          get_hotspot/1,
-         hotspot_to_geo_json/1]).
+         to_geo_json/1]).
 
 
 -define(S_HOTSPOT_LIST_BEFORE, "hotspot_list_before").
@@ -17,16 +17,17 @@
 -define(S_OWNER_HOTSPOT_LIST_BEFORE, "owner_hotspot_list_before").
 -define(S_OWNER_HOTSPOT_LIST, "owner_hotspot_list").
 -define(S_HOTSPOT, "hotspot").
--define(S_HOTSPOT_LIST_CITY, "hotspot_list_city").
--define(S_HOTSPOT_LIST_CITY_BEFORE, "hotspor_list_city_before").
 -define(S_CITY_HOTSPOT_LIST, "hotspot_city_list").
--define(S_CITY_HOTSPOT_LIST_BEFORE, "hotspor_city_list_before").
+-define(S_CITY_HOTSPOT_LIST_BEFORE, "hotspot_city_list_before").
 
 -define(SELECT_HOTSPOT_BASE(G),
         ["select (select max(height) from blocks) as height, ",
          "g.last_block, g.first_block, g.address, g.owner, g.location, g.score, g.nonce, ",
          "s.online as online_status, s.gps as gps_status, s.block as block_status, "
-         "l.short_street, l.long_street, l.short_city, l.long_city, l.short_state, l.long_state, l.short_country, l.long_country ",
+         "l.short_street, l.long_street, ",
+         "l.short_city, l.long_city, ",
+         "l.short_state, l.long_state, ",
+         "l.short_country, l.long_country ",
          G,
          " left join locations l on g.location = l.location ",
          " left join gateway_status s on s.address = g.address "
@@ -35,23 +36,7 @@
 -define(SELECT_OWNER_HOTSPOT,
         ?SELECT_HOTSPOT_BASE(["from (select * from gateway_inventory"
                               "      where owner = $1 order by first_block desc, address) as g"])).
--define(SELECT_HOTSPOT_CITY_BASE(G),
-        ["select last(l.short_city), l.long_city, last(l.short_state), last(l.long_state), last(l.short_country), last(l.long_country), count(*) ",
-         "from locations l inner join gateway_inventory g on g.location = l.location "
-         "where l.search_city like lower($1) ",
-         G,
-         "group by l.long_city "
-         "order by long_city ",
-         "limit ", integer_to_list(?HOTSPOT_LIST_CITY_LIMIT)
-        ]
-       ).
-
--define(SELECT_CITY_HOTSPOT,
-       [?SELECT_HOTSPOT_BASE,
-        " where l.long_city = $1"
-       ]).
 -define(HOTSPOT_LIST_LIMIT, 100).
--define(HOTSPOT_LIST_CITY_LIMIT, 100).
 
 prepare_conn(Conn) ->
     {ok, S1} = epgsql:parse(Conn, ?S_HOTSPOT_LIST_BEFORE,
@@ -79,25 +64,17 @@ prepare_conn(Conn) ->
                            [?SELECT_HOTSPOT_BASE,
                             "where g.address = $1"], []),
 
-    {ok, S6} = epgsql:parse(Conn, ?S_HOTSPOT_LIST_CITY,
-                            ?SELECT_HOTSPOT_CITY_BASE("")
-                           , []),
-
-    {ok, S7} = epgsql:parse(Conn, ?S_HOTSPOT_LIST_CITY_BEFORE,
-                            ?SELECT_HOTSPOT_CITY_BASE(" and l.long_city > $2")
-                           , []),
-
-    {ok, S8} = epgsql:parse(Conn, ?S_CITY_HOTSPOT_LIST_BEFORE,
+    {ok, S6} = epgsql:parse(Conn, ?S_CITY_HOTSPOT_LIST_BEFORE,
                             [?SELECT_HOTSPOT_BASE,
-                             "where l.long_city = $1 ",
-                             "and (g.address > $2 and g.first_block = $3) or (g.first_block < $3) ",
+                             "where l.long_country = lower($1) and l.long_state = lower($2) and l.long_city = lower($3)",
+                             "and (g.address > $4 and g.first_block = $5) or (g.first_block < $6) ",
                              "order by g.address "
                              "limit ", integer_to_list(?HOTSPOT_LIST_LIMIT)
                            ], []),
 
-    {ok, S9} = epgsql:parse(Conn, ?S_CITY_HOTSPOT_LIST,
+    {ok, S7} = epgsql:parse(Conn, ?S_CITY_HOTSPOT_LIST,
                             [?SELECT_HOTSPOT_BASE,
-                             "where l.long_city = $1 ",
+                             "where l.long_country = lower($1) and l.long_state = lower($2) and l.long_city = lower($3) ",
                              "order by g.first_block desc, g.address limit ", integer_to_list(?HOTSPOT_LIST_LIMIT)],
                             []),
 
@@ -107,24 +84,14 @@ prepare_conn(Conn) ->
       ?S_OWNER_HOTSPOT_LIST_BEFORE => S3,
       ?S_OWNER_HOTSPOT_LIST => S4,
       ?S_HOTSPOT => S5,
-      ?S_HOTSPOT_LIST_CITY => S6,
-      ?S_HOTSPOT_LIST_CITY_BEFORE => S7,
-      ?S_CITY_HOTSPOT_LIST_BEFORE => S8,
-      ?S_CITY_HOTSPOT_LIST => S9
+      ?S_CITY_HOTSPOT_LIST_BEFORE => S6,
+      ?S_CITY_HOTSPOT_LIST => S7
      }.
 
 
 handle('GET', [], Req) ->
     Args = ?GET_ARGS([cursor], Req),
     ?MK_RESPONSE(get_hotspot_list([{owner, undefined}, {city, undefined} | Args]), block_time);
-handle('GET', [<<"cities">>], Req) ->
-    Args = ?GET_ARGS([search, cursor], Req),
-    Result = get_hotspot_city_list(Args),
-    ?MK_RESPONSE(Result, block_time);
-handle('GET', [<<"cities">>, City], Req) ->
-    Args = ?GET_ARGS([cursor], Req),
-    Result = get_hotspot_list([{owner, undefined}, {city, elli_request:uri_decode(City)} | Args]),
-    ?MK_RESPONSE(Result, block_time);
 handle('GET', [Address], _Req) ->
     ?MK_RESPONSE(get_hotspot(Address), block_time);
 handle('GET', [Address, <<"activity">>], Req) ->
@@ -141,20 +108,6 @@ handle('GET', [Address, <<"challenges">>], Req) ->
 
 handle(_, _, _Req) ->
     ?RESPONSE_404.
-
-
-get_hotspot_city_list([{search, Search}, {cursor, undefined}]) ->
-    Result = ?PREPARED_QUERY(?S_HOTSPOT_LIST_CITY, [search_format(Search)]),
-    mk_hotspot_city_list_from_result(undefined, Result);
-get_hotspot_city_list([{search, _Search}, {cursor, Cursor}]) ->
-    case ?CURSOR_DECODE(Cursor) of
-        {ok, #{<<"before_city">> := BeforeCity }=C} ->
-            Search = maps:get(<<"search">>, C, undefined),
-            Result = ?PREPARED_QUERY(?S_HOTSPOT_LIST_CITY_BEFORE, [search_format(Search), BeforeCity]),
-            mk_hotspot_city_list_from_result(Search, Result);
-        _ ->
-            {error, badarg}
-    end.
 
 
 get_hotspot_list([{owner, undefined}, {city, undefined}, {cursor, undefined}]) ->
@@ -197,18 +150,6 @@ get_hotspot(Address) ->
         _ ->
             {error, not_found}
     end.
-
-search_format(undefined) ->
-    <<"%">>;
-search_format(Search) ->
-    Escaped = lists:foldl(fun({C, Replace}, Acc) ->
-                                  binary:replace(Acc, C, Replace, [global])
-                          end, Search,
-                          [
-                           {<<"%">>, <<"\%">>},
-                           {<<"_">>, <<"\_">>}
-                          ]),
-    <<"%", Escaped/binary, "%">>.
 
 mk_hotspot_list_from_result(undefined, {ok, _, Results}) ->
     %% no cursor, return a result
@@ -265,24 +206,6 @@ mk_cursor(Results) when is_list(Results) ->
             end
     end.
 
-mk_hotspot_city_list_from_result(Search, {ok, _, Results}) ->
-    {ok, hotspot_city_list_to_json(Results), mk_city_list_cursor(Search, Results)}.
-
-mk_city_list_cursor(Search, Results) when is_list(Results) ->
-    case length(Results) < ?HOTSPOT_LIST_CITY_LIMIT of
-        true ->
-            undefined;
-        false ->
-            {_ShortCity, LongCity,
-             _ShortState, _LongState,
-             _ShortCountry, _LongCountry, _Count} = lists:last(Results),
-            Base = #{ before_city => LongCity },
-            case Search of
-                undefined -> Base;
-                _ -> Base#{ search => Search }
-            end
-    end.
-
 %%
 %% to_jaon
 %%
@@ -290,22 +213,18 @@ mk_city_list_cursor(Search, Results) when is_list(Results) ->
 hotspot_list_to_json(Results) ->
     lists:map(fun hotspot_to_json/1, Results).
 
-hotspot_city_list_to_json(Results) ->
-    lists:map(fun hotspot_city_to_json/1, Results).
-
-
-hotspot_to_geo_json({ShortStreet, LongStreet,
+to_geo_json({ShortStreet, LongStreet,
                      ShortCity, LongCity,
                      ShortState, LongState,
                      ShortCountry, LongCountry}) ->
-    Base = hotspot_to_geo_json({ShortCity, LongCity,
-                                ShortState, LongState,
-                                ShortCountry, LongCountry}),
+    Base = to_geo_json({ShortCity, LongCity,
+                        ShortState, LongState,
+                        ShortCountry, LongCountry}),
     Base#{
           short_street => ShortStreet,
           long_street => LongStreet
          };
-hotspot_to_geo_json({ShortCity, LongCity,
+to_geo_json({ShortCity, LongCity,
                      ShortState, LongState,
                      ShortCountry, LongCountry}) ->
     #{
@@ -336,10 +255,10 @@ hotspot_to_json({Height, ScoreBlock, FirstBlock, Address, Owner, Location,
                       name => list_to_binary(Name),
                       owner => Owner,
                       location => Location,
-                      geocode => hotspot_to_geo_json({ShortStreet, LongStreet,
-                                                      ShortCity, LongCity,
-                                                      ShortState, LongState,
-                                                      ShortCountry, LongCountry}),
+                      geocode => to_geo_json({ShortStreet, LongStreet,
+                                              ShortCity, LongCity,
+                                              ShortState, LongState,
+                                              ShortCountry, LongCountry}),
                       score_update_height => ScoreBlock,
                       score => Score,
                       block_added => FirstBlock,
@@ -353,11 +272,3 @@ hotspot_to_json({Height, ScoreBlock, FirstBlock, Address, Owner, Location,
                       nonce => MaybeZero(Nonce)
                      }).
 
-hotspot_city_to_json({ShortCity, LongCity,
-                      ShortState, LongState,
-                      ShortCountry, LongCountry,
-                      Count}) ->
-    Base = hotspot_to_geo_json({ShortCity, LongCity,
-                                ShortState, LongState,
-                                ShortCountry, LongCountry}),
-    Base#{ count => Count }.

--- a/src/bh_route_txns.erl
+++ b/src/bh_route_txns.erl
@@ -401,7 +401,7 @@ txn_to_json({<<"poc_receipts_v1">>,
     Geocode = fun(PathElem = #{ <<"challengee_location">> := ChallengeeLoc}) ->
                       case ?PREPARED_QUERY(?S_LOC, [ChallengeeLoc]) of
                           {ok, _, [Result]} ->
-                              PathElem#{<<"geocode">> => bh_route_hotspots:hotspot_to_geo_json(Result)};
+                              PathElem#{<<"geocode">> => bh_route_hotspots:to_geo_json(Result)};
                           _ ->
                               PathElem
                       end

--- a/src/bh_routes.erl
+++ b/src/bh_routes.erl
@@ -33,6 +33,8 @@ handle(Method, [<<"v1">>, <<"vars">> | Tail], Req) ->
     bh_route_vars:handle(Method, Tail, Req);
 handle(Method, [<<"v1">>, <<"snapshots">> | Tail], Req) ->
     bh_route_snapshots:handle(Method, Tail, Req);
+handle(Method, [<<"v1">>, <<"cities">> | Tail], Req) ->
+    bh_route_cities:handle(Method, Tail, Req);
 handle('GET', [], _Req) ->
     {200, [], <<>>};
 

--- a/test/bh_route_cities_SUITE.erl
+++ b/test/bh_route_cities_SUITE.erl
@@ -1,0 +1,54 @@
+-module(bh_route_cities_SUITE).
+
+-compile([nowarn_export_all, export_all]).
+
+-include("bh_route_handler.hrl").
+
+-include("ct_utils.hrl").
+
+all() -> [
+          city_list_test,
+          city_search_test,
+          city_hotspots_test
+         ].
+
+init_per_suite(Config) ->
+    ?init_bh(Config).
+
+end_per_suite(Config) ->
+    ?end_bh(Config).
+
+
+
+city_list_test(_Config) ->
+    {ok, {_, _, Json}} = ?json_request(["/v1/cities"]),
+    #{ <<"data">> := Data,
+       <<"cursor">> := Cursor } = Json,
+    ?assert(length(Data) >= 0),
+
+    {ok, {_, _, NextJson}} = ?json_request(["/v1/cities?cursor=", Cursor]),
+    #{ <<"data">> := NextData } = NextJson,
+    ?assert(length(NextData) >= 0),
+    ok.
+
+city_search_test(_Config) ->
+    {ok, {_, _, Json}} = ?json_request(["/v1/cities?search=ma"]),
+    #{ <<"data">> := Data,
+       <<"cursor">> := Cursor } = Json,
+    ?assert(length(Data) >= 0),
+
+    {ok, {_, _, NextJson}} = ?json_request(["/v1/cities?cursor=", Cursor]),
+    #{ <<"data">> := NextData } = NextJson,
+    ?assert(length(NextData) >= 0),
+    ok.
+
+city_hotspots_test(_Config) ->
+    {ok, {_, _, Json}} = ?json_request(["/v1/cities/c2FuIGZyYW5jaXNjb2NhbGlmb3JuaWF1bml0ZWQgc3RhdGVz/hotspots"]),
+    #{ <<"data">> := Data,
+       <<"cursor">> := Cursor } = Json,
+    ?assert(length(Data) >= 0),
+
+    {ok, {_, _, NextJson}} = ?json_request(["/v1/cities/c2FuIGZyYW5jaXNjb2NhbGlmb3JuaWF1bml0ZWQgc3RhdGVz/hotspots?cursor=", Cursor]),
+    #{ <<"data">> := NextData } = NextJson,
+    ?assert(length(NextData) >= 0),
+    ok.

--- a/test/bh_route_hotspots_SUITE.erl
+++ b/test/bh_route_hotspots_SUITE.erl
@@ -14,10 +14,7 @@ all() -> [
           activity_low_block_test,
           activity_filter_no_result_test,
           elections_test,
-          challenges_test,
-          list_city_test,
-          list_city_search_test,
-          city_list_test
+          challenges_test
          ].
 
 init_per_suite(Config) ->
@@ -119,35 +116,3 @@ challenges_test(_Config) ->
 
     ok.
 
-list_city_test(_Config) ->
-    {ok, {_, _, Json}} = ?json_request(["/v1/hotspots/cities"]),
-    #{ <<"data">> := Data,
-       <<"cursor">> := Cursor } = Json,
-    ?assert(length(Data) >= 0),
-
-    {ok, {_, _, NextJson}} = ?json_request(["/v1/hotspots/cities?cursor=", Cursor]),
-    #{ <<"data">> := NextData } = NextJson,
-    ?assert(length(NextData) >= 0),
-    ok.
-
-list_city_search_test(_Config) ->
-    {ok, {_, _, Json}} = ?json_request(["/v1/hotspots/cities?search=s"]),
-    #{ <<"data">> := Data,
-       <<"cursor">> := Cursor } = Json,
-    ?assert(length(Data) >= 0),
-
-    {ok, {_, _, NextJson}} = ?json_request(["/v1/hotspots/cities?cursor=", Cursor]),
-    #{ <<"data">> := NextData } = NextJson,
-    ?assert(length(NextData) >= 0),
-    ok.
-
-city_list_test(_Config) ->
-    {ok, {_, _, Json}} = ?json_request(["/v1/hotspots/cities/San%20Francisco"]),
-    #{ <<"data">> := Data,
-       <<"cursor">> := Cursor } = Json,
-    ?assert(length(Data) >= 0),
-
-    {ok, {_, _, NextJson}} = ?json_request(["/v1/hotspots/cities/San%20Francisco?cursor=", Cursor]),
-    #{ <<"data">> := NextData } = NextJson,
-    ?assert(length(NextData) >= 0),
-    ok.


### PR DESCRIPTION
This moves the cites routes from hotspots to their own top level route:

* `/v1/cities` lists known cities with their hotspot counts
* `/v1/cities?search=:term` lists cities matching the given term
* `/v1/cities/:city_id/hotspots` lists hotspots in a given `city_id` where the city_id was encoded in the city list results