### PR TITLE
Convert token_burn memo field to b64

### DIFF
--- a/src/bh_route_txns.erl
+++ b/src/bh_route_txns.erl
@@ -435,6 +435,13 @@ txn_to_json({<<"assert_location_v1">>,
                <<"location">> := Location
               } = Fields}) ->
     ?INSERT_LAT_LON(Location, Fields);
+txn_to_json({<<"token_burn_v1">>,
+           #{
+             <<"memo">> := Memo
+            } = Fields}) ->
+    Fields#{
+            <<"memo">> => base64:encode(<<Memo:64/unsigned-little-integer>>)
+           };
 txn_to_json({_, Fields}) ->
     Fields.
 


### PR DESCRIPTION
The memo field is a big number which javascript/json libraries have trouble with. This encodes the memo as an unsigned little endian base64 encoded 64 bit integer which is how console outputs it to the user as well, and the wallet CLI consumes. 