### PR TITLE
Convert token_burn memo field to b64

### DIFF
--- a/src/bh_route_txns.erl
+++ b/src/bh_route_txns.erl
@@ -435,6 +435,18 @@ txn_to_json({<<"assert_location_v1">>,
                <<"location">> := Location
               } = Fields}) ->
     ?INSERT_LAT_LON(Location, Fields);
+txn_to_json({<<"token_burn_v1">>,
+           #{
+             <<"memo">> := Memo
+            } = Fields}) ->
+    %% Adjust for some memos being base64 and others still integers
+    MemoStr = case is_integer(Memo) of
+                  true -> base64:encode(<<Memo:64/unsigned-little-integer>>);
+                  _ -> Memo
+              end,
+    Fields#{
+            <<"memo">> => MemoStr
+           };
 txn_to_json({_, Fields}) ->
     Fields.
 


### PR DESCRIPTION
Adjust for some json burn transactions still having integer memo fields