### PR TITLE
Add rewards stats

### DIFF
--- a/priv/rewards.sql
+++ b/priv/rewards.sql
@@ -1,6 +1,6 @@
 -- :reward_block_range
 with max as (
-     select height from blocks where timestamp <= $1 order by height desc limit 1
+     select height from blocks where timestamp < $1 order by height desc limit 1
 ),
 min as (
     select height from blocks where timestamp >= $2 order by height limit 1
@@ -11,7 +11,7 @@ select (select height from max) as max, (select height from min) as min
 select :fields
 from rewards r
 :scope
-and r.block >= $2 and r.block < $3
+and r.block >= $2 and r.block <= $3
 order by r.block desc, r.transaction_hash
 
 -- :reward_list_rem_base
@@ -32,14 +32,14 @@ select
     coalesce(stddev(r.amount) / 100000000, 0)::float as stddev
 from rewards r
 :scope
-and r.block >= $2 and r.block < $3
+and r.block >= $2 and r.block <= $3
 
 -- :reward_stats_base
 with time_range as (
     select generate_series(date_trunc($4::text, $2::timestamptz), date_trunc($4::text, $3::timestamptz), $5) as timestamp
 ),
 max as (
-    select height from blocks where timestamp <= (select max(timestamp) from time_range) order by height desc limit 1
+    select height from blocks where timestamp < (select max(timestamp) from time_range) order by height desc limit 1
 ),
 min as (
     select height from blocks where timestamp >= (select min(timestamp) from time_range) order by height limit 1

--- a/priv/rewards.sql
+++ b/priv/rewards.sql
@@ -1,0 +1,72 @@
+-- :reward_block_range
+with max as (
+     select height from blocks where timestamp <= $1 order by height desc limit 1
+),
+min as (
+    select height from blocks where timestamp >= $2 order by height limit 1
+)
+select (select height from max) as max, (select height from min) as min
+
+-- :reward_list_base
+select :fields
+from rewards r
+:scope
+and r.block >= $2 and r.block < $3
+order by r.block desc, r.transaction_hash
+
+-- :reward_list_rem_base
+select :fields
+from rewards r
+:scope
+and r.block = $2 and r.transaction_hash > $3
+order by r.transaction_hash
+
+-- :reward_sum_base
+select
+    coalesce(min(r.amount) / 100000000, 0)::float as min,
+    coalesce(max(r.amount) / 100000000, 0)::float as max,
+    coalesce(sum(r.amount), 0)::bigint as sum,
+    coalesce(sum(r.amount) / 100000000, 0)::float as total,
+    coalesce(percentile_cont(0.5) within group (order by r.amount) / 100000000, 0)::float as median,
+    coalesce(avg(r.amount) / 100000000, 0)::float as avg,
+    coalesce(stddev(r.amount) / 100000000, 0)::float as stddev
+from rewards r
+:scope
+and r.block >= $2 and r.block < $3
+
+-- :reward_stats_base
+with time_range as (
+    select generate_series(date_trunc($4::text, $2::timestamptz), date_trunc($4::text, $3::timestamptz), $5) as timestamp
+),
+max as (
+    select height from blocks where timestamp <= (select max(timestamp) from time_range) order by height desc limit 1
+),
+min as (
+    select height from blocks where timestamp >= (select min(timestamp) from time_range) order by height limit 1
+),
+data as (
+    select
+        min(r.amount) as min,
+        max(r.amount) as max,
+        sum(r.amount) as sum,
+        percentile_cont(0.5) within group (order by r.amount) as median,
+        avg(r.amount) as avg,
+        stddev(r.amount) as stddev,
+        date_trunc($4::text, to_timestamp(r.time)) as timestamp
+    from rewards r
+    :scope
+    and r.block >= (select height from min) and r.block <= (select height from max)
+    group by date_trunc($4::text, to_timestamp(r.time))
+)
+select
+    t.timestamp,
+    coalesce(d.min / 100000000, 0)::float as min,
+    coalesce(d.max / 100000000, 0)::float as max,
+    coalesce(d.sum, 0)::bigint as sum,
+    coalesce(d.sum / 100000000, 0)::float as total,
+    coalesce(d.median / 100000000, 0)::float as median,
+    coalesce(d.avg / 100000000, 0)::float as avg,
+    coalesce(d.stddev / 100000000, 0)::float as stddev
+from time_range t left join data d on t.timestamp = d.timestamp
+where t.timestamp < (select max(timestamp) from time_range)
+order by t.timestamp desc;

--- a/priv/stats.sql
+++ b/priv/stats.sql
@@ -95,11 +95,15 @@ select (sum(balance) / 100000000)::float as token_supply from account_inventory
 
 -- State channel details
 -- :stats_state_channels
- with month_interval as (
-     select to_timestamp(b.time) as timestamp,
+with min as (
+    select height from blocks where timestamp > (now() - '1 month'::interval) order by height limit 1
+),
+ month_interval as (
+    select
+        to_timestamp(t.time) as timestamp,
         state_channel_counts(t.type, t.fields) as counts
-     from blocks b inner join transactions t on b.height = t.block
-     where to_timestamp(b.time) > (now() - '1 month'::interval)
+     from transactions t
+     where t.block > (select height from min)
          and t.type = 'state_channel_close_v1'
  ),
  week_interval as (

--- a/src/bh_route_accounts.erl
+++ b/src/bh_route_accounts.erl
@@ -156,6 +156,9 @@ handle('GET', [Account, <<"rewards">>], Req) ->
 handle('GET', [Account, <<"rewards">>, <<"sum">>], Req) ->
     Args = ?GET_ARGS([max_time, min_time], Req),
     ?MK_RESPONSE(bh_route_rewards:get_reward_sum({account, Account}, Args), block_time);
+handle('GET', [Account, <<"rewards">>, <<"stats">>], Req) ->
+    Args = ?GET_ARGS([max_time, min_time, bucket], Req),
+    ?MK_RESPONSE(bh_route_rewards:get_reward_stats({account, Account}, Args), block_time);
 handle('GET', [Account, <<"pending_transactions">>], Req) ->
     Args = ?GET_ARGS([cursor], Req),
     ?MK_RESPONSE(bh_route_pending_txns:get_pending_txn_list({actor, Account}, Args), never);

--- a/src/bh_route_hotspots.erl
+++ b/src/bh_route_hotspots.erl
@@ -217,6 +217,9 @@ handle('GET', [Address, <<"rewards">>], Req) ->
 handle('GET', [Address, <<"rewards">>, <<"sum">>], Req) ->
     Args = ?GET_ARGS([max_time, min_time], Req),
     ?MK_RESPONSE(bh_route_rewards:get_reward_sum({hotspot, Address}, Args), block_time);
+handle('GET', [Address, <<"rewards">>, <<"stats">>], Req) ->
+    Args = ?GET_ARGS([max_time, min_time, bucket], Req),
+    ?MK_RESPONSE(bh_route_rewards:get_reward_stats({hotspot, Address}, Args), block_time);
 handle('GET', [Address, <<"witnesses">>], _Req) ->
     ?MK_RESPONSE(get_hotspot_list([{witnesses_for, Address}]), block_time);
 handle(_, _, _Req) ->

--- a/src/bh_route_stats.erl
+++ b/src/bh_route_stats.erl
@@ -12,13 +12,22 @@
 -define(S_STATS_BLOCK_TIMES, "stats_block_times").
 -define(S_STATS_ELECTION_TIMES, "stats_election_times").
 -define(S_STATS_STATE_CHANNELS, "stats_state_channels").
--define(S_TOKEN_SUPPLY, "stats_token_supply").
+-define(S_STATS_TOKEN_SUPPLY, "stats_token_supply").
 -define(S_STATS_COUNTS, "stats_counts").
 -define(S_STATS_CHALLENGES, "stats_challenges").
 -define(S_STATS_FEES, "stats_fees").
 
 prepare_conn(Conn) ->
-    bh_db_worker:load_from_eql(Conn, "stats.sql").
+    Loads = [
+        ?S_STATS_BLOCK_TIMES,
+        ?S_STATS_ELECTION_TIMES,
+        ?S_STATS_COUNTS,
+        ?S_STATS_CHALLENGES,
+        ?S_STATS_STATE_CHANNELS,
+        ?S_STATS_TOKEN_SUPPLY,
+        ?S_STATS_FEES
+    ],
+    bh_db_worker:load_from_eql(Conn, "stats.sql", Loads).
 
 handle('GET', [], _Req) ->
     ?MK_RESPONSE(get_stats(), block_time);
@@ -29,7 +38,7 @@ handle(_, _, _Req) ->
     ?RESPONSE_404.
 
 get_token_supply([{format, Format}], CacheTime) ->
-    Result = ?PREPARED_QUERY(?S_TOKEN_SUPPLY, []),
+    Result = ?PREPARED_QUERY(?S_STATS_TOKEN_SUPPLY, []),
     case Format of
         <<"raw">> ->
             Headers = [{<<"Content-Type">>, <<"text/plain">>}],
@@ -53,7 +62,7 @@ get_stats() ->
             {?S_STATS_BLOCK_TIMES, []},
             {?S_STATS_ELECTION_TIMES, []},
             {?S_STATS_STATE_CHANNELS, []},
-            {?S_TOKEN_SUPPLY, []},
+            {?S_STATS_TOKEN_SUPPLY, []},
             {?S_STATS_COUNTS, []},
             {?S_STATS_CHALLENGES, []},
             {?S_STATS_FEES, []}

--- a/src/bh_route_vars.erl
+++ b/src/bh_route_vars.erl
@@ -9,12 +9,19 @@
 %% Utilities
 -export([get_var_list/0, get_var/1]).
 
-
 -define(S_VAR_LIST, "var_list").
 -define(S_VAR, "var_get").
 
 prepare_conn(Conn) ->
-    bh_db_worker:load_from_eql(Conn, "vars.sql").
+    Loads = [
+        {?S_VAR_LIST, []},
+        {?S_VAR, []}
+    ],
+    bh_db_worker:load_from_eql(
+        Conn,
+        "vars.sql",
+        Loads
+    ).
 
 handle('GET', [], _Req) ->
     ?MK_RESPONSE(get_var_list(), block_time);
@@ -25,14 +32,13 @@ handle('GET', [<<"activity">>], Req) ->
     ?MK_RESPONSE(Result, CacheTime);
 handle('GET', [Name], _Req) ->
     ?MK_RESPONSE(get_var(Name), block_time);
-
 handle(_, _, _Req) ->
     ?RESPONSE_404.
 
 add_filter_types(Args) ->
     Args ++ [{filter_types, <<"vars_v1">>}].
 
-get_var_list()  ->
+get_var_list() ->
     {ok, _, Results} = ?PREPARED_QUERY(?S_VAR_LIST, []),
     {ok, var_list_to_json(Results)}.
 
@@ -44,7 +50,6 @@ get_var(Name) ->
         _ ->
             {error, not_found}
     end.
-
 
 %%
 %% json
@@ -63,15 +68,14 @@ var_to_json({Name, <<"atom">>, <<"false">>}) ->
     {Name, false};
 var_to_json({Name, <<"atom">>, Value}) ->
     {Name, Value};
-var_to_json({<<"staking_keys">>=Name, <<"binary">>, Value}) ->
+var_to_json({<<"staking_keys">> = Name, <<"binary">>, Value}) ->
     {Name, b64_to_keys(Value)};
-var_to_json({<<"price_oracle_public_keys">>=Name, <<"binary">>, Value}) ->
+var_to_json({<<"price_oracle_public_keys">> = Name, <<"binary">>, Value}) ->
     {Name, b64_to_keys(Value)};
 var_to_json({Name, <<"binary">>, Value}) ->
     {Name, Value}.
 
-
 b64_to_keys(Value) ->
     Bin = ?B64_TO_BIN(Value),
-    BinKeys = [ Key || << Len:8/unsigned-integer, Key:Len/binary >> <= Bin ],
+    BinKeys = [Key || <<Len:8/unsigned-integer, Key:Len/binary>> <= Bin],
     [?BIN_TO_B58(Key) || Key <- BinKeys].

--- a/test/bh_route_accounts_SUITE.erl
+++ b/test/bh_route_accounts_SUITE.erl
@@ -17,6 +17,7 @@ all() ->
         stats_test,
         rewards_test,
         rewards_sum_test,
+        rewards_stats_test,
         rich_list_test
     ].
 
@@ -142,10 +143,22 @@ rewards_sum_test(_Config) ->
     {ok, {_, _, Json}} = ?json_request([
         "/v1/accounts/",
         Account,
-        "/rewards/sum/?max_time=2020-08-27&min_time=2019-01-01"
+        "/rewards/sum?max_time=2020-08-27&min_time=2019-01-01"
     ]),
     #{<<"data">> := #{<<"sum">> := Sum}} = Json,
     ?assert(Sum >= 0),
+
+    ok.
+
+rewards_stats_test(_Config) ->
+    Account = "13YuCz3mZ55HZ6hJJvQHCZXGgE8ooe2CSvbtSHQR3m5vZ1EVCNZ",
+    {ok, {_, _, Json}} = ?json_request([
+        "/v1/accounts/",
+        Account,
+        "/rewards/stats?max_time=2020-09-27&min_time=2020-08-27&bucket=day"
+    ]),
+    #{<<"data">> := Data} = Json,
+    ?assertEqual(31, length(Data)),
 
     ok.
 

--- a/test/bh_route_hotspots_SUITE.erl
+++ b/test/bh_route_hotspots_SUITE.erl
@@ -19,6 +19,7 @@ all() ->
         challenges_test,
         rewards_test,
         rewards_sum_test,
+        rewards_stats_test,
         witnesses_test
     ].
 
@@ -183,6 +184,18 @@ rewards_sum_test(_Config) ->
     ]),
     #{<<"data">> := #{<<"sum">> := Sum}} = Json,
     ?assert(Sum >= 0),
+
+    ok.
+
+rewards_stats_test(_Config) ->
+    Hotspot = "112DCTVEbFi8azQ2KmhSDW2UqRM2ijmiMWKJptnhhPEk3uXvwLyK",
+    {ok, {_, _, Json}} = ?json_request([
+        "/v1/hotspots/",
+        Hotspot,
+        "/rewards/stats?max_time=2020-09-27&min_time=2020-08-27&bucket=day"
+    ]),
+    #{<<"data">> := Data} = Json,
+    ?assertEqual(31, length(Data)),
 
     ok.
 


### PR DESCRIPTION
This exposes a new rewards/stats route for both accounts and hotspots:

* `/v1/accounts/:address/rewards/stats`
* `/v1/hotspots/:address/rewards/stats`

Both take the following parameters:

* `min_time`: The start time to get statistics for
* `max_time`: The end time to get statistics for
* `bucket`: one of `month`, `week`, `day`, `hour`

The api will bucket the time between min and max_time after _truncating_ their timestamp to the nearest bucket boundary. For each bucket the result includes :

* `timestamp`: the iso8601 timestamp the bucket started at
* `sum`: Total rewards in the bucket
* `avg`: Average rewards in the bucket
* `median`: Median rewards in the bucket
* `stddev`: Standard deviation of rewards in the bucket
* `max`: The maximum reward in the bucket
* `min`: The minimum rewards in the bucket

In addition the `rewards/sum` endpoints for both accounts and hotspots have been extended to return `avg`, `median`, and `stddev` in addition to the `sum` result

This fixes #129 