### PR TITLE
Bucket non hotspot specific sum/stats per hotspot

### DIFF
--- a/priv/stats.sql
+++ b/priv/stats.sql
@@ -139,11 +139,11 @@ with heights as (
 month_interval as (
     select
         t.block as block,
-        sum((t.fields->>'fee')::numeric) as fees,
-        sum(coalesce((t.fields->>'staking_fee')::numeric, 0)::numeric) as staking_fees
+        sum(coalesce((t.fields->>'fee')::numeric, 0)) as fees,
+        sum(coalesce((t.fields->>'staking_fee')::numeric, 0)) as staking_fees
     from transactions t
     where t.block > (select month from heights)
-        and (t.fields->>'fee')::numeric > 0
+        and t.type not in ('poc_receipts_v1', 'poc_request_v1', 'rewards_v1', 'consensus_group_v1')
     group by t.block
 ),
 week_interval as (

--- a/src/bh_route_accounts.erl
+++ b/src/bh_route_accounts.erl
@@ -87,11 +87,8 @@ handle('GET', [Account, <<"rewards">>], Req) ->
     Args = ?GET_ARGS([cursor, max_time, min_time], Req),
     ?MK_RESPONSE(bh_route_rewards:get_reward_list({account, Account}, Args), block_time);
 handle('GET', [Account, <<"rewards">>, <<"sum">>], Req) ->
-    Args = ?GET_ARGS([max_time, min_time], Req),
-    ?MK_RESPONSE(bh_route_rewards:get_reward_sum({account, Account}, Args), block_time);
-handle('GET', [Account, <<"rewards">>, <<"stats">>], Req) ->
     Args = ?GET_ARGS([max_time, min_time, bucket], Req),
-    ?MK_RESPONSE(bh_route_rewards:get_reward_stats({account, Account}, Args), block_time);
+    ?MK_RESPONSE(bh_route_rewards:get_reward_sum({account, Account}, Args), block_time);
 handle('GET', [Account, <<"pending_transactions">>], Req) ->
     Args = ?GET_ARGS([cursor], Req),
     ?MK_RESPONSE(bh_route_pending_txns:get_pending_txn_list({actor, Account}, Args), never);

--- a/src/bh_route_handler.erl
+++ b/src/bh_route_handler.erl
@@ -5,7 +5,7 @@
 -export([
     get_args/2,
     parse_timespan/2,
-    parse_bucket/1,
+    parse_bucket/2,
     parse_interval/1,
     parse_interval/2,
     parse_bucketed_timespan/3,
@@ -102,9 +102,9 @@ parse_timespan(MaxTime0, MinTime0) ->
             {error, Error}
     end.
 
--spec parse_bucket(binary()) -> {ok, interval_spec()} | {error, term()}.
-parse_bucket(Bin) ->
-    parse_interval(1, Bin).
+-spec parse_bucket(integer(), binary()) -> {ok, interval_spec()} | {error, term()}.
+parse_bucket(N, Bin) ->
+    parse_interval(N, Bin).
 
 -spec parse_interval(binary()) -> {ok, interval_spec()} | {error, term()}.
 parse_interval(Bin) ->
@@ -146,7 +146,7 @@ interval_to_seconds({{H, M, S}, D, 0}) ->
 parse_bucketed_timespan(MaxTime0, MinTime0, Bucket0) ->
     case parse_timespan(MaxTime0, MinTime0) of
         {ok, {MaxTime, MinTime}} ->
-            case parse_bucket(Bucket0) of
+            case parse_bucket(-1, Bucket0) of
                 {ok, Bucket} -> {ok, {{MaxTime, MinTime}, Bucket}};
                 {error, Error} -> {error, Error}
             end;

--- a/src/bh_route_hotspots.erl
+++ b/src/bh_route_hotspots.erl
@@ -163,11 +163,12 @@ handle('GET', [Address, <<"rewards">>], Req) ->
     Args = ?GET_ARGS([cursor, max_time, min_time], Req),
     ?MK_RESPONSE(bh_route_rewards:get_reward_list({hotspot, Address}, Args), block_time);
 handle('GET', [Address, <<"rewards">>, <<"sum">>], Req) ->
-    Args = ?GET_ARGS([max_time, min_time], Req),
-    ?MK_RESPONSE(bh_route_rewards:get_reward_sum({hotspot, Address}, Args), block_time);
-handle('GET', [Address, <<"rewards">>, <<"stats">>], Req) ->
     Args = ?GET_ARGS([max_time, min_time, bucket], Req),
-    ?MK_RESPONSE(bh_route_rewards:get_reward_stats({hotspot, Address}, Args), block_time);
+    ?MK_RESPONSE(bh_route_rewards:get_reward_sum({hotspot, Address}, Args), block_time);
+handle('GET', [<<"rewards">>, <<"sum">>], Req) ->
+    %% We do not allow bucketing across all hotspots as that takes way too long
+    Args = ?GET_ARGS([max_time, min_time], Req),
+    ?MK_RESPONSE(bh_route_rewards:get_reward_sum({hotspot, all}, Args), block_time);
 handle('GET', [Address, <<"witnesses">>], _Req) ->
     ?MK_RESPONSE(get_hotspot_list([{witnesses_for, Address}]), block_time);
 handle(_, _, _Req) ->

--- a/test/bh_route_accounts_SUITE.erl
+++ b/test/bh_route_accounts_SUITE.erl
@@ -3,7 +3,6 @@
 -compile([nowarn_export_all, export_all]).
 
 -include("bh_route_handler.hrl").
-
 -include("ct_utils.hrl").
 
 all() ->
@@ -17,7 +16,7 @@ all() ->
         stats_test,
         rewards_test,
         rewards_sum_test,
-        rewards_stats_test,
+        rewards_buckets_test,
         rich_list_test
     ].
 
@@ -101,7 +100,7 @@ stats_test(_Config) ->
     {ok, {_, _, Json}} = ?json_request(["/v1/accounts/", Account, "/stats"]),
     #{<<"data">> := Data} = Json,
     lists:foreach(
-        fun(Key) ->
+        fun (Key) ->
             Entry = maps:get(Key, Data),
             ?assert(length(Entry) > 0)
         end,
@@ -114,11 +113,12 @@ stats_test(_Config) ->
 
 rewards_test(_Config) ->
     Account = "13YuCz3mZ55HZ6hJJvQHCZXGgE8ooe2CSvbtSHQR3m5vZ1EVCNZ",
-    {ok, {_, _, Json}} = ?json_request([
-        "/v1/accounts/",
-        Account,
-        "/rewards?max_time=2020-08-27&min_time=2019-01-01"
-    ]),
+    {ok, {_, _, Json}} =
+        ?json_request([
+            "/v1/accounts/",
+            Account,
+            "/rewards?max_time=2020-08-27&min_time=2019-01-01"
+        ]),
     #{<<"data">> := Data} = Json,
     ?assert(length(Data) >= 0),
 
@@ -126,12 +126,13 @@ rewards_test(_Config) ->
         undefined ->
             ok;
         Cursor ->
-            {ok, {_, _, CursorJson}} = ?json_request([
-                "/v1/accounts/",
-                Account,
-                "/rewards?cursor=",
-                Cursor
-            ]),
+            {ok, {_, _, CursorJson}} =
+                ?json_request([
+                    "/v1/accounts/",
+                    Account,
+                    "/rewards?cursor=",
+                    Cursor
+                ]),
             #{<<"data">> := CursorData} = CursorJson,
             ?assert(length(CursorData) >= 0)
     end,
@@ -140,23 +141,25 @@ rewards_test(_Config) ->
 
 rewards_sum_test(_Config) ->
     Account = "13YuCz3mZ55HZ6hJJvQHCZXGgE8ooe2CSvbtSHQR3m5vZ1EVCNZ",
-    {ok, {_, _, Json}} = ?json_request([
-        "/v1/accounts/",
-        Account,
-        "/rewards/sum?max_time=2020-08-27&min_time=2019-01-01"
-    ]),
+    {ok, {_, _, Json}} =
+        ?json_request([
+            "/v1/accounts/",
+            Account,
+            "/rewards/sum?max_time=2020-08-27&min_time=2019-01-01"
+        ]),
     #{<<"data">> := #{<<"sum">> := Sum}} = Json,
     ?assert(Sum >= 0),
 
     ok.
 
-rewards_stats_test(_Config) ->
+rewards_buckets_test(_Config) ->
     Account = "13YuCz3mZ55HZ6hJJvQHCZXGgE8ooe2CSvbtSHQR3m5vZ1EVCNZ",
-    {ok, {_, _, Json}} = ?json_request([
-        "/v1/accounts/",
-        Account,
-        "/rewards/stats?max_time=2020-09-27&min_time=2020-08-27&bucket=day"
-    ]),
+    {ok, {_, _, Json}} =
+        ?json_request([
+            "/v1/accounts/",
+            Account,
+            "/rewards/sum?max_time=2020-09-27&min_time=2020-08-27&bucket=day"
+        ]),
     #{<<"data">> := Data} = Json,
     ?assertEqual(31, length(Data)),
 

--- a/test/bh_route_hotspots_SUITE.erl
+++ b/test/bh_route_hotspots_SUITE.erl
@@ -20,7 +20,7 @@ all() ->
         challenges_test,
         rewards_test,
         rewards_sum_test,
-        rewards_stats_test,
+        rewards_buckets_test,
         witnesses_test
     ].
 
@@ -214,13 +214,13 @@ rewards_sum_test(_Config) ->
 
     ok.
 
-rewards_stats_test(_Config) ->
+rewards_buckets_test(_Config) ->
     Hotspot = "112DCTVEbFi8azQ2KmhSDW2UqRM2ijmiMWKJptnhhPEk3uXvwLyK",
     {ok, {_, _, Json}} =
         ?json_request([
             "/v1/hotspots/",
             Hotspot,
-            "/rewards/stats?max_time=2020-09-27&min_time=2020-08-27&bucket=day"
+            "/rewards/sum?max_time=2020-09-27&min_time=2020-08-27&bucket=day"
         ]),
     #{<<"data">> := Data} = Json,
     ?assertEqual(31, length(Data)),


### PR DESCRIPTION
In order to be able to compare stats with other _hotspots_ vs for a single hotspot we need to bucket reward sums by hotspot as well as the time bucket.

This change adds bucketing by hotspot within each time bucket for any route that includes more than one hotspot. i.e. account sum/stats. For a single hotspot the rewards are not bucketed by hotspot but just by time.

We also add a `hotspots/rewards/stats` route which buckets hotspot stats between min/max time and by hotspot within a each bucket.