### PR TITLE
Remove score from api

### DIFF
--- a/src/bh_route_hotspots.erl
+++ b/src/bh_route_hotspots.erl
@@ -402,10 +402,6 @@ hotspot_to_json(
                     ShortCountry, LongCountry, CityId}
             ),
             last_change_block => LastChangeBlock,
-            %% TODO: REMOVE
-            score_update_height => LastChangeBlock,
-            %% TODO: REMOVE
-            score => 1.0,
             block_added => FirstBlock,
             timestamp_added => iso8601:format(FirstTimestamp),
             block => Height,


### PR DESCRIPTION
This _removes_ the `score` and `last_score_block` from the API  as announced in the [engineering blog](https://engineering.helium.com/2020/12/02/helium-api-update-removing-the-score.html)

Fixes #136 