### PR TITLE
Add election/elected hotspots

### DIFF
--- a/priv/hotspots.sql
+++ b/priv/hotspots.sql
@@ -1,0 +1,79 @@
+-- :hotspot_list_base
+select 
+    (select max(height) from blocks) as height,
+    g.last_block, 
+    g.first_block, 
+    g.first_timestamp, 
+    g.address,
+    g.owner, 
+    g.location, 
+    g.nonce, 
+    g.name,
+    s.online as online_status, 
+    s.block as block_status,
+    l.short_street, l.long_street,
+    l.short_city, l.long_city,
+    l.short_state, l.long_state,
+    l.short_country, l.long_country,
+    l.city_id
+    :source
+left join locations l on g.location = l.location
+left join gateway_status s on s.address = g.address
+:scope
+:order
+:limit 
+
+-- :hotspot_list_order
+order by g.first_block desc, g.address
+
+-- :hotspot_list_source
+from gateway_inventory g
+
+-- :hotspot_list_before_scope
+where ((g.address > $1 and g.first_block = $2) or (g.first_block < $2))
+
+-- :owner_hotspot_list_source
+from (select * from gateway_inventory where owner = $1) as g
+
+-- :owner_hotspot_list_before_scope
+where ((g.address > $2 and g.first_block = $3) or (g.first_block < $3))
+
+-- :city_hotspot_list_before_scope
+where l.city_id = $1
+and ((g.address > $2 and g.first_block = $3) or (g.first_block < $3))
+
+-- :city_hotspot_list_before_scope
+where l.city_id = $1
+and ((g.address > $2 and g.first_block = $3) or (g.first_block < $3))
+
+-- :city_hotspot_list_scope
+where l.city_id = $1
+
+-- :hotspot_witness_list
+with hotspot_witnesses as (
+    select gi.address as witness_for, w.key as witness, w.value as witness_info
+    from gateway_inventory gi, jsonb_each(gi.witnesses) w where gi.address = $1
+)
+:hotspot_select
+
+-- :hotspot_witness_list_source
+, g.witness_for, g.witness_info
+from (select * from hotspot_witnesses w inner join gateway_inventory i on (w.witness = i.address)) g
+
+-- :hotspot_elected_list
+with field_members as (
+    select fields->'members' as members
+    from transactions
+    where type = 'consensus_group_v1' :filter
+    order by block desc 
+    limit 1
+),
+members as (
+    select * 
+    from jsonb_array_elements_text((select members from field_members))
+)
+:hotspot_select
+
+-- :hotspot_elected_list_scope
+where g.address in (select * from members)
+

--- a/test/bh_route_hotspots_SUITE.erl
+++ b/test/bh_route_hotspots_SUITE.erl
@@ -3,7 +3,6 @@
 -compile([nowarn_export_all, export_all]).
 
 -include("bh_route_handler.hrl").
-
 -include("ct_utils.hrl").
 
 all() ->
@@ -16,6 +15,8 @@ all() ->
         activity_filter_no_result_test,
         elections_test,
         elected_test,
+        elected_block_test,
+        elected_hash_test,
         challenges_test,
         rewards_test,
         rewards_sum_test,
@@ -120,7 +121,8 @@ elections_test(_Config) ->
     } = Json,
     ?assert(length(Data) >= 0),
 
-    {ok, {_, _, NextJson}} = ?json_request(["/v1/hotspots/", Hotspot, "/elections?cursor=", Cursor]),
+    {ok, {_, _, NextJson}} =
+        ?json_request(["/v1/hotspots/", Hotspot, "/elections?cursor=", Cursor]),
     #{<<"data">> := NextData} = NextJson,
     ?assert(length(NextData) >= 0),
 
@@ -128,6 +130,27 @@ elections_test(_Config) ->
 
 elected_test(_Config) ->
     {ok, {_, _, Json}} = ?json_request(["/v1/hotspots/elected"]),
+    #{
+        <<"data">> := Data
+    } = Json,
+    ?assert(length(Data) > 0),
+
+    ok.
+
+elected_block_test(_Config) ->
+    {ok, {_, _, Json}} = ?json_request(["/v1/hotspots/elected/93"]),
+    #{
+        <<"data">> := Data
+    } = Json,
+    ?assert(length(Data) > 0),
+
+    ok.
+
+elected_hash_test(_Config) ->
+    {ok, {_, _, Json}} =
+        ?json_request([
+            "/v1/hotspots/elected/hash/5cBTF9x8DN1DhUNVmQExXHWAXID6BZIxJG-LLx4KzSs"
+        ]),
     #{
         <<"data">> := Data
     } = Json,
@@ -144,7 +167,8 @@ challenges_test(_Config) ->
     } = Json,
     ?assert(length(Data) >= 0),
 
-    {ok, {_, _, NextJson}} = ?json_request(["/v1/hotspots/", Hotspot, "/challenges?cursor=", Cursor]),
+    {ok, {_, _, NextJson}} =
+        ?json_request(["/v1/hotspots/", Hotspot, "/challenges?cursor=", Cursor]),
     #{<<"data">> := NextData} = NextJson,
     ?assert(length(NextData) >= 0),
 
@@ -152,11 +176,12 @@ challenges_test(_Config) ->
 
 rewards_test(_Config) ->
     Hotspot = "112DCTVEbFi8azQ2KmhSDW2UqRM2ijmiMWKJptnhhPEk3uXvwLyK",
-    {ok, {_, _, Json}} = ?json_request([
-        "/v1/hotspots/",
-        Hotspot,
-        "/rewards?max_time=2020-08-27&min_time=2019-01-01"
-    ]),
+    {ok, {_, _, Json}} =
+        ?json_request([
+            "/v1/hotspots/",
+            Hotspot,
+            "/rewards?max_time=2020-08-27&min_time=2019-01-01"
+        ]),
     #{<<"data">> := Data} = Json,
     ?assert(length(Data) >= 0),
 
@@ -164,12 +189,13 @@ rewards_test(_Config) ->
         undefined ->
             ok;
         Cursor ->
-            {ok, {_, _, CursorJson}} = ?json_request([
-                "/v1/hotspots/",
-                Hotspot,
-                "/rewards?cursor=",
-                Cursor
-            ]),
+            {ok, {_, _, CursorJson}} =
+                ?json_request([
+                    "/v1/hotspots/",
+                    Hotspot,
+                    "/rewards?cursor=",
+                    Cursor
+                ]),
             #{<<"data">> := CursorData} = CursorJson,
             ?assert(length(CursorData) >= 0)
     end,
@@ -177,11 +203,12 @@ rewards_test(_Config) ->
 
 rewards_sum_test(_Config) ->
     Hotspot = "112DCTVEbFi8azQ2KmhSDW2UqRM2ijmiMWKJptnhhPEk3uXvwLyK",
-    {ok, {_, _, Json}} = ?json_request([
-        "/v1/hotspots/",
-        Hotspot,
-        "/rewards/sum?max_time=2020-08-27&min_time=2019-01-01"
-    ]),
+    {ok, {_, _, Json}} =
+        ?json_request([
+            "/v1/hotspots/",
+            Hotspot,
+            "/rewards/sum?max_time=2020-08-27&min_time=2019-01-01"
+        ]),
     #{<<"data">> := #{<<"sum">> := Sum}} = Json,
     ?assert(Sum >= 0),
 
@@ -189,11 +216,12 @@ rewards_sum_test(_Config) ->
 
 rewards_stats_test(_Config) ->
     Hotspot = "112DCTVEbFi8azQ2KmhSDW2UqRM2ijmiMWKJptnhhPEk3uXvwLyK",
-    {ok, {_, _, Json}} = ?json_request([
-        "/v1/hotspots/",
-        Hotspot,
-        "/rewards/stats?max_time=2020-09-27&min_time=2020-08-27&bucket=day"
-    ]),
+    {ok, {_, _, Json}} =
+        ?json_request([
+            "/v1/hotspots/",
+            Hotspot,
+            "/rewards/stats?max_time=2020-09-27&min_time=2020-08-27&bucket=day"
+        ]),
     #{<<"data">> := Data} = Json,
     ?assertEqual(31, length(Data)),
 
@@ -201,11 +229,12 @@ rewards_stats_test(_Config) ->
 
 witnesses_test(_Config) ->
     Hotspot = "112hYxknRPeCP9PLtkAy3f86fWpXaRzRffjPj5HcrS7qePttY3Ek",
-    {ok, {_, _, Json}} = ?json_request([
-        "/v1/hotspots/",
-        Hotspot,
-        "/witnesses"
-    ]),
+    {ok, {_, _, Json}} =
+        ?json_request([
+            "/v1/hotspots/",
+            Hotspot,
+            "/witnesses"
+        ]),
     #{<<"data">> := Data} = Json,
     ?assert(length(Data) >= 0),
 


### PR DESCRIPTION
Expands the `v1/hotspots/elected` route with 

1. `v1/hotspots/elected` - lists "currently elected" hotspots
2. `v1/hotspots/elected/<block>` - lists the elected hotspots that were active at the given block height
3. `v1/hotspost/elected/hash/<hash>` - lists the elected hotspots in the given transaction hash. The transaction identified by the given hash is required to be a `consensus_group_v1`  

Fixes: #145 