### PR TITLE
Add locations route to look up a location

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -31,7 +31,8 @@
             bh_route_snapshots,
             bh_route_cities,
             bh_route_rewards,
-            bh_route_ouis
+            bh_route_ouis,
+            bh_route_locations
         ]},
         {db_rw_handlers, [
             bh_route_pending_txns

--- a/priv/locations.sql
+++ b/priv/locations.sql
@@ -1,0 +1,11 @@
+-- :location_list_base
+select 
+    l.short_street, l.long_street,
+    l.short_city, l.long_city,
+    l.short_state, l.long_state,
+    l.short_country, l.long_country,
+    l.city_id,
+    l.location
+from locations l
+:scope
+

--- a/src/bh_route_locations.erl
+++ b/src/bh_route_locations.erl
@@ -1,0 +1,59 @@
+-module(bh_route_locations).
+
+-behavior(bh_route_handler).
+-behavior(bh_db_worker).
+
+-include("bh_route_handler.hrl").
+
+-export([prepare_conn/1, handle/3]).
+%% Utilities
+-export([get_location/1]).
+
+-define(S_LOCATION, "location_at_index").
+
+prepare_conn(Conn) ->
+    Loads = [
+        {?S_LOCATION,
+            {location_list_base, [
+                {scope, "where location = $1"}
+            ]}}
+    ],
+    bh_db_worker:load_from_eql(Conn, "locations.sql", Loads).
+
+handle('GET', [Location], _Req) ->
+    ?MK_RESPONSE(get_location(Location), infinity);
+handle(_, _, _Req) ->
+    ?RESPONSE_404.
+
+get_location(Location) ->
+    case ?PREPARED_QUERY(?S_LOCATION, [Location]) of
+        {ok, _, [Result]} ->
+            {ok, location_to_json(Result)};
+        _ ->
+            {error, not_found}
+    end.
+
+%%
+%% json
+%%
+
+location_to_json(
+    {ShortStreet, LongStreet, ShortCity, LongCity, ShortState, LongState, ShortCountry,
+        LongCountry, CityId, Location}
+) ->
+    MaybeB64 = fun
+        (null) -> null;
+        (Bin) -> ?BIN_TO_B64(Bin)
+    end,
+    #{
+        short_street => ShortStreet,
+        long_street => LongStreet,
+        short_city => ShortCity,
+        long_city => LongCity,
+        short_state => ShortState,
+        long_state => LongState,
+        short_country => ShortCountry,
+        long_country => LongCountry,
+        city_id => MaybeB64(CityId),
+        location => Location
+    }.

--- a/src/bh_routes.erl
+++ b/src/bh_routes.erl
@@ -38,6 +38,8 @@ handle(Method, [<<"v1">>, <<"cities">> | Tail], Req) ->
     bh_route_cities:handle(Method, Tail, Req);
 handle(Method, [<<"v1">>, <<"ouis">> | Tail], Req) ->
     bh_route_ouis:handle(Method, Tail, Req);
+handle(Method, [<<"v1">>, <<"locations">> | Tail], Req) ->
+    bh_route_locations:handle(Method, Tail, Req);
 handle('GET', [], _Req) ->
     {200, [], <<>>};
 handle(_, _, _Req) ->

--- a/test/bh_route_locations_SUITE.erl
+++ b/test/bh_route_locations_SUITE.erl
@@ -1,0 +1,22 @@
+-module(bh_route_locations_SUITE).
+
+-compile([nowarn_export_all, export_all]).
+
+-include("ct_utils.hrl").
+
+all() ->
+    [
+        get_test
+    ].
+
+init_per_suite(Config) ->
+    ?init_bh(Config).
+
+end_per_suite(Config) ->
+    ?end_bh(Config).
+
+get_test(_Config) ->
+    {ok, {_, _, Json}} = ?json_request("/v1/locations/8c28347213117ff"),
+    #{<<"data">> := _} = Json,
+
+    ok.


### PR DESCRIPTION
Adds a `v1/locations/:location` that takes an h3 location index and returns geo json.

Fixes #163 