### PR TITLE
Construct hotspot witness statistics

### DIFF
--- a/src/bh_route_rewards.erl
+++ b/src/bh_route_rewards.erl
@@ -197,21 +197,6 @@ get_blockspan(MaxTime0, MinTime0) ->
             {error, Error}
     end.
 
--spec get_bucketed_blockspan(High :: binary(), Low :: binary(), Bucket :: binary()) ->
-    {ok,
-        {bh_route_handler:timespan(), bh_route_handler:blockspan(),
-            bh_route_handler:interval_spec()}} |
-    {error, term()}.
-get_bucketed_blockspan(MaxTime0, MinTime0, BucketType0) ->
-    case ?PARSE_BUCKETED_TIMESPAN(MaxTime0, MinTime0, BucketType0) of
-        {ok, {{MaxTime, MinTime}, {BucketType, BucketStep}}} ->
-            {ok, _, [{HighBlock, LowBlock}]} =
-                ?PREPARED_QUERY(?S_BLOCK_RANGE, [MaxTime, MinTime]),
-            {ok, {{MaxTime, MinTime}, {HighBlock, LowBlock}, {BucketType, BucketStep}}};
-        {error, Error} ->
-            {error, Error}
-    end.
-
 get_reward_list(
     Args,
     {Query, _RemQuery},
@@ -273,8 +258,8 @@ get_reward_bucketed_sum(Args, Query, [
     {min_time, MinTime0},
     {bucket, BucketType0}
 ]) ->
-    case get_bucketed_blockspan(MaxTime0, MinTime0, BucketType0) of
-        {ok, {{MaxTime, MinTime}, _, {BucketType, BucketStep}}} ->
+    case ?PARSE_BUCKETED_TIMESPAN(MaxTime0, MinTime0, BucketType0) of
+        {ok, {{MaxTime, MinTime}, {BucketType, BucketStep}}} ->
             Result = ?PREPARED_QUERY(
                 Query,
                 Args ++ [MaxTime, MinTime, BucketStep]

--- a/test/bh_route_hotspots_SUITE.erl
+++ b/test/bh_route_hotspots_SUITE.erl
@@ -22,7 +22,8 @@ all() ->
         rewards_all_sum_test,
         rewards_sum_test,
         rewards_buckets_test,
-        witnesses_test
+        witnesses_test,
+        witnesses_buckets_test
     ].
 
 init_per_suite(Config) ->
@@ -246,6 +247,19 @@ witnesses_test(_Config) ->
             "/v1/hotspots/",
             Hotspot,
             "/witnesses"
+        ]),
+    #{<<"data">> := Data} = Json,
+    ?assert(length(Data) >= 0),
+
+    ok.
+
+witnesses_buckets_test(_Config) ->
+    Hotspot = "112hYxknRPeCP9PLtkAy3f86fWpXaRzRffjPj5HcrS7qePttY3Ek",
+    {ok, {_, _, Json}} =
+        ?json_request([
+            "/v1/hotspots/",
+            Hotspot,
+            "/witnesses/sum?max_time=2020-09-27&min_time=2020-08-27&bucket=day"
         ]),
     #{<<"data">> := Data} = Json,
     ?assert(length(Data) >= 0),


### PR DESCRIPTION
Introduces a new endpoint `/v1/hotspots/:address/witnesses/sum` to return stats for witnesses for a give hotspot. 

This takes the same min_time, max_time, bucket parameters as the reward sum endpoints, and returns min, max, median, avg, stddev stats for witness counts in each bucket.

Fixes #166 