### PR TITLE
Fix duplicate rewards in reward cursor paged lists

### DIFF
--- a/priv/rewards.sql
+++ b/priv/rewards.sql
@@ -1,25 +1,33 @@
 -- :reward_block_range
 with max as (
-     select height from blocks where timestamp < $1 order by height desc limit 1
+     select height from blocks where timestamp <= $1 order by height desc limit 1
 ),
 min as (
     select height from blocks where timestamp >= $2 order by height limit 1
 )
 select (select height from max) as max, (select height from min) as min
 
+-- :reward_fields
+r.block, r.transaction_hash, to_timestamp(r.time) as timestamp, r.account, r.gateway, r.amount
+
+-- Make sure that marker fields and fields are equivalent except for the marker
+-- placeholder!
+-- :reward_marker_fields
+r.block, r.transaction_hash, to_timestamp(r.time) as timestamp, r.account, r.gateway, r.amount, :marker
+
 -- :reward_list_base
 select :fields
 from rewards r
 :scope
-and r.block >= $2 and r.block <= $3
-order by r.block desc, r.transaction_hash
+and r.block >= $2 and r.block < $3
+order by r.block desc, :marker
 
 -- :reward_list_rem_base
 select :fields
 from rewards r
 :scope
-and r.block = $2 and r.transaction_hash > $3
-order by r.transaction_hash
+and r.block = $2 and :marker> $3
+order by :marker
 
 -- :reward_sum_hotspot_source
 (select

--- a/test/bh_route_hotspots_SUITE.erl
+++ b/test/bh_route_hotspots_SUITE.erl
@@ -193,12 +193,7 @@ rewards_test(_Config) ->
             ok;
         Cursor ->
             {ok, {_, _, CursorJson}} =
-                ?json_request([
-                    "/v1/hotspots/",
-                    Hotspot,
-                    "/rewards?cursor=",
-                    Cursor
-                ]),
+                ?json_request(["/v1/hotspots/", Hotspot, "/rewards?cursor=", Cursor]),
             #{<<"data">> := CursorData} = CursorJson,
             ?assert(length(CursorData) >= 0)
     end,

--- a/test/ct_utils.erl
+++ b/test/ct_utils.erl
@@ -1,4 +1,5 @@
 -module(ct_utils).
+
 -compile([nowarn_export_all, export_all]).
 
 -include_lib("common_test/include/ct.hrl").
@@ -18,15 +19,26 @@ end_bh(Config) ->
     Config.
 
 request(Path) ->
-    httpc:request(get, {lists:flatten(["http://localhost:8080", Path]), []}, [], [{body_format, binary}]).
+    httpc:request(get, {lists:flatten(["http://localhost:8080", Path]), []}, [], [
+        {body_format, binary}
+    ]).
 
 json_request(Path) ->
     case ?MODULE:request(Path) of
-        {ok, {Status={_, 200, _}, Headers, Body}} ->
+        {ok, {Status = {_, 200, _}, Headers, Body}} ->
             Json = jiffy:decode(Body, [return_maps]),
             {ok, {Status, Headers, Json}};
         {ok, {Status, _Headers, _Body}} ->
             {error, Status};
         {error, Error} ->
             {error, Error}
+    end.
+
+fold_json_request(Fun, Base, {ok, {_, _, Json}}, Acc) ->
+    NewAcc = lists:foldl(Fun, Acc, maps:get(<<"data">>, Json)),
+    case maps:get(<<"cursor">>, Json, undefined) of
+        undefined ->
+            NewAcc;
+        Cursor ->
+            fold_json_request(Fun, Base, json_request([Base, "?cursor=", Cursor]), NewAcc)
     end.


### PR DESCRIPTION
This adds a helper to bh_route_rewards to get a full reward list without paging, and a ct_utils helper to walk through an api cursor folding over the paged data.

Fixes #174 