### PR TITLE
Add activity count routes for acccounts/hotspots

### DIFF
--- a/src/bh_route_accounts.erl
+++ b/src/bh_route_accounts.erl
@@ -77,6 +77,9 @@ handle('GET', [Account, <<"activity">>], Req) ->
     Result = bh_route_txns:get_activity_list({account, Account}, Args),
     CacheTime = bh_route_txns:get_txn_list_cache_time(Result),
     ?MK_RESPONSE(Result, CacheTime);
+handle('GET', [Account, <<"activity">>, <<"count">>], Req) ->
+    Args = ?GET_ARGS([filter_types], Req),
+    ?MK_RESPONSE(bh_route_txns:get_activity_count({account, Account}, Args), block_time);
 handle('GET', [Account, <<"elections">>], Req) ->
     Args = ?GET_ARGS([cursor], Req),
     ?MK_RESPONSE(

--- a/src/bh_route_hotspots.erl
+++ b/src/bh_route_hotspots.erl
@@ -159,6 +159,9 @@ handle('GET', [Address, <<"activity">>], Req) ->
     Result = bh_route_txns:get_activity_list({hotspot, Address}, Args),
     CacheTime = bh_route_txns:get_txn_list_cache_time(Result),
     ?MK_RESPONSE(Result, CacheTime);
+handle('GET', [Address, <<"activity">>, <<"count">>], Req) ->
+    Args = ?GET_ARGS([filter_types], Req),
+    ?MK_RESPONSE(bh_route_txns:get_activity_count({hotspot, Address}, Args), block_time);
 handle('GET', [Address, <<"elections">>], Req) ->
     Args = ?GET_ARGS([cursor], Req),
     ?MK_RESPONSE(
@@ -327,11 +330,10 @@ mk_cursor(Results) when is_list(Results) ->
             undefined;
         false ->
             case lists:last(Results) of
-                {Height, _LastChangeBlock, FirstBlock, _FirstTimestamp, _LastPocChallenge,
-                    Address, _Owner, _Location, _Nonce, _Name, _RewardScale, _OnlineStatus,
-                    _BlockStatus, _ListenAddrs, _ShortStreet, _LongStreet, _ShortCity,
-                    _LongCity, _ShortState, _LongState, _ShortCountry, _LongCountry,
-                    _CityId} ->
+                {Height, _LastChangeBlock, FirstBlock, _FirstTimestamp, _LastPocChallenge, Address,
+                    _Owner, _Location, _Nonce, _Name, _RewardScale, _OnlineStatus, _BlockStatus,
+                    _ListenAddrs, _ShortStreet, _LongStreet, _ShortCity, _LongCity, _ShortState,
+                    _LongState, _ShortCountry, _LongCountry, _CityId} ->
                     #{
                         before_address => Address,
                         before_block => FirstBlock,
@@ -362,8 +364,8 @@ hotspot_witness_list_to_json(Results) ->
     lists:map(fun hotspot_witness_to_json/1, Results).
 
 to_geo_json(
-    {ShortStreet, LongStreet, ShortCity, LongCity, ShortState, LongState, ShortCountry,
-        LongCountry, CityId}
+    {ShortStreet, LongStreet, ShortCity, LongCity, ShortState, LongState, ShortCountry, LongCountry,
+        CityId}
 ) ->
     Base = to_geo_json(
         {ShortCity, LongCity, ShortState, LongState, ShortCountry, LongCountry, CityId}
@@ -391,15 +393,15 @@ to_geo_json(
 
 hotspot_witness_to_json(
     {Height, LastChangeBlock, FirstBlock, FirstTimestamp, LastPoCChallenge, Address, Owner,
-        Location, Nonce, Name, RewardScale, OnlineStatus, BlockStatus, ListenAddrs,
-        ShortStreet, LongStreet, ShortCity, LongCity, ShortState, LongState, ShortCountry,
-        LongCountry, CityId, WitnessFor, WitnessInfo}
+        Location, Nonce, Name, RewardScale, OnlineStatus, BlockStatus, ListenAddrs, ShortStreet,
+        LongStreet, ShortCity, LongCity, ShortState, LongState, ShortCountry, LongCountry, CityId,
+        WitnessFor, WitnessInfo}
 ) ->
     Base = hotspot_to_json(
-        {Height, LastChangeBlock, FirstBlock, FirstTimestamp, LastPoCChallenge, Address,
-            Owner, Location, Nonce, Name, RewardScale, OnlineStatus, BlockStatus,
-            ListenAddrs, ShortStreet, LongStreet, ShortCity, LongCity, ShortState,
-            LongState, ShortCountry, LongCountry, CityId}
+        {Height, LastChangeBlock, FirstBlock, FirstTimestamp, LastPoCChallenge, Address, Owner,
+            Location, Nonce, Name, RewardScale, OnlineStatus, BlockStatus, ListenAddrs, ShortStreet,
+            LongStreet, ShortCity, LongCity, ShortState, LongState, ShortCountry, LongCountry,
+            CityId}
     ),
     Base#{
         witness_for => WitnessFor,
@@ -408,9 +410,8 @@ hotspot_witness_to_json(
 
 hotspot_to_json(
     {Height, LastChangeBlock, FirstBlock, FirstTimestamp, LastPoCChallenge, Address, Owner,
-        Location, Nonce, Name, RewardScale, OnlineStatus, BlockStatus, ListenAddrs,
-        ShortStreet, LongStreet, ShortCity, LongCity, ShortState, LongState, ShortCountry,
-        LongCountry, CityId}
+        Location, Nonce, Name, RewardScale, OnlineStatus, BlockStatus, ListenAddrs, ShortStreet,
+        LongStreet, ShortCity, LongCity, ShortState, LongState, ShortCountry, LongCountry, CityId}
 ) ->
     MaybeZero = fun
         (null) -> 0;
@@ -424,8 +425,8 @@ hotspot_to_json(
             owner => Owner,
             location => Location,
             geocode => to_geo_json(
-                {ShortStreet, LongStreet, ShortCity, LongCity, ShortState, LongState,
-                    ShortCountry, LongCountry, CityId}
+                {ShortStreet, LongStreet, ShortCity, LongCity, ShortState, LongState, ShortCountry,
+                    LongCountry, CityId}
             ),
             last_change_block => LastChangeBlock,
             last_poc_challenge => LastPoCChallenge,

--- a/test/bh_route_accounts_SUITE.erl
+++ b/test/bh_route_accounts_SUITE.erl
@@ -9,6 +9,7 @@ all() ->
     [
         get_test,
         not_found_test,
+        activity_count_test,
         activity_result_test,
         activity_low_block_test,
         activity_filter_no_result_test,
@@ -41,6 +42,20 @@ get_test(_Config) ->
 
 not_found_test(_Config) ->
     ?assertMatch({error, {_, 404, _}}, ?json_request("/v1/accounts/no_account/no_path")),
+    ok.
+
+activity_count_test(_Config) ->
+    Account = "1122ZQigQfeeyfSmH2i4KM4XMQHouBqK4LsTp33ppP3W2Knqh8gY",
+    {ok, {_, _, Json}} = ?json_request([
+        "/v1/accounts/",
+        Account,
+        "/activity/count?filter_types=payment_v1"
+    ]),
+    #{
+        <<"data">> := Data
+    } = Json,
+    ?assertEqual(1, maps:size(Data)),
+    ?assert(maps:get(<<"payment_v1">>, Data) >= 0),
     ok.
 
 activity_result_test(_Config) ->

--- a/test/bh_route_hotspots_SUITE.erl
+++ b/test/bh_route_hotspots_SUITE.erl
@@ -10,6 +10,7 @@ all() ->
         list_test,
         get_test,
         not_found_test,
+        activity_count_test,
         activity_result_test,
         activity_low_block_test,
         activity_filter_no_result_test,
@@ -68,6 +69,21 @@ get_named_test(_Config) ->
 
 not_found_test(_Config) ->
     ?assertMatch({error, {_, 404, _}}, ?json_request("/v1/hotspots/no_address")),
+    ok.
+
+activity_count_test(_Config) ->
+    Hotspot = "112DCTVEbFi8azQ2KmhSDW2UqRM2ijmiMWKJptnhhPEk3uXvwLyK",
+    {ok, {_, _, Json}} = ?json_request([
+        "/v1/hotspots/",
+        Hotspot,
+        "/activity/count?filter_types=add_gateway_v1,assert_location_v1"
+    ]),
+    #{
+        <<"data">> := Data
+    } = Json,
+    ?assertEqual(2, maps:size(Data)),
+    ?assertEqual(maps:get(<<"add_gateway_v1">>, Data), 1),
+    ?assert(maps:get(<<"assert_location_v1">>, Data) >= 0),
     ok.
 
 activity_result_test(_Config) ->


### PR DESCRIPTION
This adds:

* `/v1/accounts/:address/activity/count` which takes a `filter_types` query parameter and returns a map of counts for the given transaction types
* `/v1/hotspots/:address/activity/count` which takes a `filter_types` query parameter and returns a map of counts for the given transaction types

Fixes: #198 