### PR TITLE
Add location search to hotspots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,4 @@ _build
 rebar3.crashdump
 .DS_Store
 data/
-.env
-.envrc
+.env*

--- a/priv/hotspots.sql
+++ b/priv/hotspots.sql
@@ -61,6 +61,26 @@ where g.name %> lower($1)
 -- :hotspot_name_search_order
 order by word_similarity(g.name, $1) desc, name
 
+-- :hotspot_location_box_search_order
+order by g.first_block desc, g.address
+
+-- :hotspot_location_box_search_scope
+where ST_Intersects(ST_MakeEnvelope($1, $2, $3, $4, 4326), l.geometry)
+
+-- :hotspot_location_box_search_before_scope
+where ST_Intersects(ST_MakeEnvelope($1, $2, $3, $4, 4326), l.geometry)
+and ((g.address > $5 and g.first_block = $6) or (g.first_block < $6))
+
+-- :hotspot_location_distance_search_order
+order by ST_Distance(ST_SetSRID(ST_MakePoint($1, $2), 4326)::geography, l.geometry::geography), g.address
+
+-- :hotspot_location_distance_search_scope
+where ST_DWithin(ST_SetSRID(ST_MakePoint($1, $2), 4326)::geography, l.geometry::geography, $3)
+
+-- :hotspot_location_distance_search_before_scope
+where ST_DWithin(ST_SetSRID(ST_MakePoint($1, $2), 4326)::geography, l.geometry::geography, $3)
+and ((g.address > $4 and g.first_block = $5) or (g.first_block < $5))
+
 -- :hotspot_witness_list
 with last_assert as (
     select t.block as height from transactions t inner join transaction_actors a on t.hash = a.transaction_hash

--- a/src/bh_db_worker.erl
+++ b/src/bh_db_worker.erl
@@ -48,7 +48,7 @@ prepared_query(shutdown, _, _) ->
     throw(?RESPONSE_503_SHUTDOWN);
 prepared_query(Pool, Name, Params) ->
     Ref = make_ref(),
-    Fun = fun (From, {Stmts, Conn}) ->
+    Fun = fun(From, {Stmts, Conn}) ->
         Statement = maps:get(Name, Stmts),
         #statement{types = Types} = Statement,
         TypedParameters = lists:zip(Types, Params),
@@ -76,9 +76,9 @@ execute_batch(shutdown, _) ->
     throw(?RESPONSE_503_SHUTDOWN);
 execute_batch(Pool, Queries) ->
     Ref = make_ref(),
-    Fun = fun (From, {Stmts, Conn}) ->
+    Fun = fun(From, {Stmts, Conn}) ->
         Batch = lists:foldr(
-            fun ({Name, Params}, Acc) ->
+            fun({Name, Params}, Acc) ->
                 Statement = maps:get(Name, Stmts),
                 [{Statement, Params} | Acc]
             end,
@@ -110,12 +110,15 @@ load_from_eql(Conn, Filename, Loads) ->
         R({K, Name}) when is_atom(Name) ->
             R({K, {Name, []}});
         R({K, {Name, Params}}) ->
-            {ok, Q} =
+            case
                 case Params of
                     [] -> eql:get_query(Name, Queries);
                     _ -> eql:get_query(Name, Queries, lists:map(R, Params))
-                end,
-            {K, Q};
+                end
+            of
+                {ok, Q} -> {K, Q};
+                undefined -> error({badarg, Name})
+            end;
         R({K, V}) ->
             {K, V}
     end,
@@ -124,7 +127,7 @@ load_from_eql(Conn, Filename, Loads) ->
             L({Key, {list_to_atom(Name), Params}});
         L({Key, {_Name, _Params}} = Entry) ->
             %% Leverage the equivalent pattern in ResolveParams to
-            %% expand out nested eql fragments and their parameters. 
+            %% expand out nested eql fragments and their parameters.
             {Key, Query} = ResolveParams(Entry),
             {ok, Statement} = epgsql:parse(Conn, Key, Query, []),
             {Key, Statement};
@@ -138,7 +141,7 @@ load_from_eql(Conn, Filename, Loads) ->
     maps:from_list(Statements).
 
 init(Args) ->
-    GetOpt = fun (K) ->
+    GetOpt = fun(K) ->
         case lists:keyfind(K, 1, Args) of
             false -> error({missing_opt, K});
             {_, V} -> V
@@ -149,7 +152,7 @@ init(Args) ->
     {ok, Conn} = epgsql:connect(DBOpts#{codecs => Codecs}),
     Handlers = GetOpt(db_handlers),
     PreparedStatements = lists:foldl(
-        fun (Mod, Acc) ->
+        fun(Mod, Acc) ->
             maps:merge(Mod:prepare_conn(Conn), Acc)
         end,
         #{},
@@ -204,7 +207,7 @@ code_change(_OldVsn, State, _Extra) ->
 
 eql_test() ->
     meck:new(epgsql),
-    meck:expect(epgsql, parse, fun (fakeconnection, _Key, Query, _Opts) -> {ok, Query} end),
+    meck:expect(epgsql, parse, fun(fakeconnection, _Key, Query, _Opts) -> {ok, Query} end),
     %% we need to load the application here so that code:priv/2 will work correctly
     ok = application:load(blockchain_http),
     Files = [

--- a/src/bh_route_handler.hrl
+++ b/src/bh_route_handler.hrl
@@ -14,6 +14,8 @@
 -define(PARSE_BUCKETED_TIMESPAN(H, L, B),
     bh_route_handler:parse_bucketed_timespan((H), (L), (B))
 ).
+-define(PARSE_FLOAT(F), bh_route_handler:parse_float((F))).
+-define(PARSE_INT(I), bh_route_handler:parse_int((I))).
 
 -define(MK_RESPONSE(R), ?MK_RESPONSE(R, undefined)).
 -define(MK_RESPONSE(R, C), bh_route_handler:mk_response((R), (C))).

--- a/src/bh_route_stats.erl
+++ b/src/bh_route_stats.erl
@@ -85,10 +85,10 @@ mk_stats_from_time_results(
     ]}
 ) ->
     #{
-        last_hour => #{avg => mk_float(LastHrAvg), stddev => mk_float(LastHrStddev)},
-        last_day => #{avg => mk_float(LastDayAvg), stddev => mk_float(LastDayStddev)},
-        last_week => #{avg => mk_float(LastWeekAvg), stddev => mk_float(LastWeekStddev)},
-        last_month => #{avg => mk_float(LastMonthAvg), stddev => mk_float(LastMonthStddev)}
+        last_hour => #{avg => ?PARSE_FLOAT(LastHrAvg), stddev => ?PARSE_FLOAT(LastHrStddev)},
+        last_day => #{avg => ?PARSE_FLOAT(LastDayAvg), stddev => ?PARSE_FLOAT(LastDayStddev)},
+        last_week => #{avg => ?PARSE_FLOAT(LastWeekAvg), stddev => ?PARSE_FLOAT(LastWeekStddev)},
+        last_month => #{avg => ?PARSE_FLOAT(LastMonthAvg), stddev => ?PARSE_FLOAT(LastMonthStddev)}
     }.
 
 mk_stats_from_state_channel_results(
@@ -97,9 +97,15 @@ mk_stats_from_state_channel_results(
     ]}
 ) ->
     #{
-        last_day => #{num_packets => mk_int(LastDayPackets), num_dcs => mk_int(LastDayDCs)},
-        last_week => #{num_packets => mk_int(LastWeekPackets), num_dcs => mk_int(LastWeekDCs)},
-        last_month => #{num_packets => mk_int(LastMonthPackets), num_dcs => mk_int(LastMonthDCs)}
+        last_day => #{num_packets => ?PARSE_INT(LastDayPackets), num_dcs => ?PARSE_INT(LastDayDCs)},
+        last_week => #{
+            num_packets => ?PARSE_INT(LastWeekPackets),
+            num_dcs => ?PARSE_INT(LastWeekDCs)
+        },
+        last_month => #{
+            num_packets => ?PARSE_INT(LastMonthPackets),
+            num_dcs => ?PARSE_INT(LastMonthDCs)
+        }
     }.
 
 mk_stats_from_fee_results(
@@ -110,16 +116,16 @@ mk_stats_from_fee_results(
 ) ->
     #{
         last_day => #{
-            transaction => mk_int(LastDayTxnFees),
-            staking => mk_int(LastDayStakingFees)
+            transaction => ?PARSE_INT(LastDayTxnFees),
+            staking => ?PARSE_INT(LastDayStakingFees)
         },
         last_week => #{
-            transaction => mk_int(LastWeekTxnFees),
-            staking => mk_int(LastWeekStakingFees)
+            transaction => ?PARSE_INT(LastWeekTxnFees),
+            staking => ?PARSE_INT(LastWeekStakingFees)
         },
         last_month => #{
-            transaction => mk_int(LastMonthTxnFees),
-            staking => mk_int(LastMonthStakingFees)
+            transaction => ?PARSE_INT(LastMonthTxnFees),
+            staking => ?PARSE_INT(LastMonthStakingFees)
         }
     }.
 
@@ -128,42 +134,11 @@ mk_stats_from_counts_results({ok, CountsResults}) ->
 
 mk_stats_from_challenge_results({ok, [{ActiveChallenges, LastDayChallenges}]}) ->
     #{
-        active => mk_int(ActiveChallenges),
-        last_day => mk_int(LastDayChallenges)
+        active => ?PARSE_INT(ActiveChallenges),
+        last_day => ?PARSE_INT(LastDayChallenges)
     }.
-
-mk_float(null) ->
-    null;
-mk_float(Bin) when is_binary(Bin) ->
-    binary_to_float(Bin);
-mk_float(Num) when is_float(Num) ->
-    Num.
-
-mk_int(null) ->
-    null;
-mk_int(Bin) when is_binary(Bin) ->
-    binary_to_integer(Bin);
-mk_int(Num) when is_integer(Num) ->
-    Num.
 
 mk_token_supply_from_result({ok, _, Result}) ->
     mk_token_supply_from_result({ok, Result});
 mk_token_supply_from_result({ok, [{TokenSupply}]}) ->
-    mk_float(TokenSupply).
-
--ifdef(TEST).
--include_lib("eunit/include/eunit.hrl").
-
-mk_int_test() ->
-    ?assertEqual(null, mk_int(null)),
-    ?assertEqual(22, mk_int(<<"22">>)),
-    ?assertEqual(22, mk_int(22)),
-    ok.
-
-mk_float_test() ->
-    ?assertEqual(null, mk_float(null)),
-    ?assertEqual(22.2, mk_float(<<"22.2">>)),
-    ?assertEqual(22.2, mk_float(22.2)),
-    ok.
-
--endif.
+    ?PARSE_FLOAT(TokenSupply).

--- a/test/bh_route_hotspots_SUITE.erl
+++ b/test/bh_route_hotspots_SUITE.erl
@@ -27,7 +27,9 @@ all() ->
         witnesses_buckets_test,
         challenges_buckets_test,
         name_test,
-        name_search_test
+        name_search_test,
+        location_distance_search_test,
+        location_box_search_test
     ].
 
 init_per_suite(Config) ->
@@ -300,4 +302,61 @@ name_search_test(_Config) ->
         <<"data">> := Results
     } = Json,
     ?assert(length(Results) >= 1),
+    ok.
+
+location_distance_search_test(_Config) ->
+    Lat = "38.12129445739087",
+    Lon = "-122.52885074963571",
+    Distance = "100000",
+    {ok, {_, _, Json}} = ?json_request([
+        "/v1/hotspots/location/distance?lat=",
+        Lat,
+        "&lon=",
+        Lon,
+        "&distance=",
+        Distance
+    ]),
+    #{
+        <<"data">> := Results,
+        <<"cursor">> := Cursor
+    } = Json,
+    ?assert(length(Results) >= 1),
+    {ok, {_, _, CursorJson}} = ?json_request([
+        "/v1/hotspots/location/distance?cursor=",
+        Cursor
+    ]),
+    #{
+        <<"data">> := CursorResults
+    } = CursorJson,
+    ?assert(length(CursorResults) >= 1),
+    ok.
+
+location_box_search_test(_Config) ->
+    SWLat = "37.7299412",
+    SWLon = "-122.5090477",
+    NELat = "37.8047205",
+    NELon = "-122.3777419",
+    {ok, {_, _, Json}} = ?json_request([
+        "/v1/hotspots/location/box?swlat=",
+        SWLat,
+        "&swlon=",
+        SWLon,
+        "&nelat=",
+        NELat,
+        "&nelon=",
+        NELon
+    ]),
+    #{
+        <<"data">> := Results,
+        <<"cursor">> := Cursor
+    } = Json,
+    ?assert(length(Results) >= 1),
+    {ok, {_, _, CursorJson}} = ?json_request([
+        "/v1/hotspots/location/box?cursor=",
+        Cursor
+    ]),
+    #{
+        <<"data">> := CursorResults
+    } = CursorJson,
+    ?assert(length(CursorResults) >= 1),
     ok.


### PR DESCRIPTION
Adds:

* /v1/hotspots/location/distance with query params `lat`, `lon`, `distance` to return hotspots with a given distance (in meters) from the given lat/lon. The result is cursor paged.

* /v1/hotspots/location/box with query params `swlat`, `swlon`, `nelat`, `nelon` to return hotspots within a given geographic boundary. The result is cursor paged.