### PR TITLE
Bump stat cache to 5 blocks (300 secs)

### DIFF
--- a/src/bh_route_stats.erl
+++ b/src/bh_route_stats.erl
@@ -30,7 +30,7 @@ prepare_conn(Conn) ->
     bh_db_worker:load_from_eql(Conn, "stats.sql", Loads).
 
 handle('GET', [], _Req) ->
-    ?MK_RESPONSE(get_stats(), block_time);
+    ?MK_RESPONSE(get_stats(), {block_time, 5});
 handle('GET', [<<"token_supply">>], Req) ->
     Args = ?GET_ARGS([format], Req),
     get_token_supply(Args, block_time);


### PR DESCRIPTION
Problem to solve: We need to execute the stats SQL much less frequently because they are quite expensive to compute.

Solution: Send headers so fastly will cache this data for 5 blocks (60 seconds * 5 = 300 seconds) instead of one block.