### PR TITLE
Adds support for `order`

### DIFF
--- a/priv/cities.sql
+++ b/priv/cities.sql
@@ -1,0 +1,74 @@
+-- :city_list_base
+with online_data as (
+    select
+        last(l.short_city) as short_city, l.long_city,
+        last(l.short_state) as short_state, l.long_state,
+        last(l.short_country) as short_country, l.long_country,
+        last(l.city_id) as city_id,
+        count(*) as hotspot_count,
+        s.online as online
+    from
+        locations l inner join gateway_inventory g on g.location = l.location
+        left join gateway_status s on s.address = g.address
+    :inner_scope
+    group by (l.long_country, l.long_state, l.long_city, s.online)
+),
+data as (
+    select
+        d.*,
+        coalesce(o.hotspot_count, 0) as online_count,
+        (d.hotspot_count - coalesce(o.hotspot_count, 0)) as offline_count,
+        :rank
+    from
+        (select
+            last(short_city) as short_city, long_city,
+            last(short_state) as short_state, long_state,
+            last(short_country) as short_country, long_country,
+            last(city_id) as city_id,
+            coalesce(sum(hotspot_count), 0) as hotspot_count
+        from online_data
+            group by (long_country, long_state, long_city)) d
+        left join online_data o on d.city_id = o.city_id and o.online = 'online'
+    )
+select
+    d.short_city, d.long_city,
+    d.short_state, d.long_state,
+    d.short_country, d.long_country,
+    d.city_id,
+    d.hotspot_count, d.online_count, d.offline_count,
+    d.rank
+from data d
+:scope
+:order
+:limit
+
+-- :city_list_count_order
+order by rank desc, city_id
+
+-- :city_list_count_rank
+case $1
+    when 'hotspot_count' then d.hotspot_count
+    when 'online_count' then coalesce(o.hotspot_count, 0)
+    when 'offline_count' then (d.hotspot_count - coalesce(o.hotspot_count, 0))
+end as rank
+
+-- :city_list_count_before_scope
+where rank <= $2 and city_id > $3
+
+-- :city_list_name_order
+order by rank, city_id
+
+-- :city_list_name_rank
+d.long_city as rank
+
+-- :city_list_name_before_scope
+where rank >= $1 and city_id > $2
+
+-- :city_search_order
+order by rank, city_id
+
+-- :city_search_rank
+word_similarity(d.long_city, $1) as rank
+
+-- :city_search_inner_scope
+where l.search_city %> lower($1)

--- a/src/bh_route_cities.erl
+++ b/src/bh_route_cities.erl
@@ -9,112 +9,65 @@
 %% Utilities
 -export([get_city_list/1]).
 
--define(S_CITY_LIST, "city_list").
--define(S_CITY_LIST_BEFORE, "city_list_before").
+-define(S_CITY_LIST_COUNT, "city_list_count").
+-define(S_CITY_LIST_COUNT_BEFORE, "city_list_count_before").
+-define(S_CITY_LIST_NAME, "city_list_name").
+-define(S_CITY_LIST_NAME_BEFORE, "city_list_name_before").
 -define(S_CITY_SEARCH, "city_search").
 -define(S_CITY_SEARCH_BEFORE, "city_search_before").
 -define(S_CITY_HOTSPOT_LIST, "hotspot_city_list").
 -define(S_CITY_HOTSPOT_LIST_BEFORE, "hotspor_city_list_before").
 
--define(SELECT_CITY_LIST_BASE, [
-    "select ",
-    "  short_city, long_city, ",
-    "  short_state, long_state, ",
-    "  short_country, long_country, ",
-    "  city_id, rank, hotspot_count ",
-    "from ",
-    "  (select",
-    "     last(l.short_city) as short_city, l.long_city, ",
-    "     last(l.short_state) as short_state, l.long_state, ",
-    "     last(l.short_country) as short_country, l.long_country, ",
-    "     last(l.city_id) as city_id, ",
-    "     count(*) as hotspot_count, ",
-    "     1 as rank ",
-    "   from locations l inner join gateway_inventory g on g.location = l.location "
-    "   group by (l.long_country, l.long_state, l.long_city) ",
-    "   order by city_id ",
-    "   ) c "
-]).
-
--define(SELECT_CITY_SEARCH_BASE, [
-    "select ",
-    "  short_city, long_city, ",
-    "  short_state, long_state, ",
-    "  short_country, long_country, ",
-    "  city_id, rank, hotspot_count ",
-    "from ",
-    "  (select",
-    "     last(l.short_city) as short_city, l.long_city, ",
-    "     last(l.short_state) as short_state, l.long_state, ",
-    "     last(l.short_country) as short_country, l.long_country, ",
-    "     last(l.city_id) as city_id, ",
-    "     count(*) as hotspot_count, ",
-    "     word_similarity(l.long_city, $1) as rank ",
-    "   from locations l inner join gateway_inventory g on g.location = l.location "
-    "   where l.search_city %> lower($1) ",
-    "   group by (l.long_country, l.long_state, l.long_city) ",
-    "   order by rank desc, city_id ",
-    "   ) c "
-]).
-
 -define(CITY_LIST_LIMIT, 100).
 
 prepare_conn(Conn) ->
-    {ok, S1} = epgsql:parse(
-        Conn,
-        ?S_CITY_SEARCH,
-        [
-            ?SELECT_CITY_SEARCH_BASE,
-            "limit ",
-            integer_to_list(?CITY_LIST_LIMIT)
-        ],
-        []
-    ),
-
-    {ok, S2} = epgsql:parse(
-        Conn,
-        ?S_CITY_SEARCH_BEFORE,
-        [
-            ?SELECT_CITY_SEARCH_BASE,
-            "where rank <= $2 and city_id > $3 ",
-            "limit ",
-            integer_to_list(?CITY_LIST_LIMIT)
-        ],
-        []
-    ),
-
-    {ok, S3} = epgsql:parse(
-        Conn,
-        ?S_CITY_LIST,
-        [
-            ?SELECT_CITY_LIST_BASE,
-            "limit ",
-            integer_to_list(?CITY_LIST_LIMIT)
-        ],
-        []
-    ),
-
-    {ok, S4} = epgsql:parse(
-        Conn,
-        ?S_CITY_LIST_BEFORE,
-        [
-            ?SELECT_CITY_LIST_BASE,
-            "where rank <= $1 and city_id > $2 ",
-            "limit ",
-            integer_to_list(?CITY_LIST_LIMIT)
-        ],
-        []
-    ),
-
-    #{
-        ?S_CITY_SEARCH => S1,
-        ?S_CITY_SEARCH_BEFORE => S2,
-        ?S_CITY_LIST => S3,
-        ?S_CITY_LIST_BEFORE => S4
-    }.
+    CityListLimit = "limit " ++ integer_to_list(?CITY_LIST_LIMIT),
+    Loads = [
+        {?S_CITY_SEARCH,
+            {city_list_base, [
+                {inner_scope, city_search_inner_scope},
+                {rank, city_search_rank},
+                {scope, ""},
+                {order, city_search_order},
+                {limit, CityListLimit}
+            ]}},
+        {?S_CITY_LIST_NAME,
+            {city_list_base, [
+                {rank, city_list_name_rank},
+                {inner_scope, ""},
+                {scope, ""},
+                {order, city_list_name_order},
+                {limit, CityListLimit}
+            ]}},
+        {?S_CITY_LIST_NAME_BEFORE,
+            {city_list_base, [
+                {rank, city_list_name_rank},
+                {inner_scope, ""},
+                {scope, city_list_name_before_scope},
+                {order, city_list_name_order},
+                {limit, CityListLimit}
+            ]}},
+        {?S_CITY_LIST_COUNT,
+            {city_list_base, [
+                {rank, city_list_count_rank},
+                {inner_scope, ""},
+                {scope, ""},
+                {order, city_list_count_order},
+                {limit, CityListLimit}
+            ]}},
+        {?S_CITY_LIST_COUNT_BEFORE,
+            {city_list_base, [
+                {rank, city_list_count_rank},
+                {inner_scope, ""},
+                {scope, city_list_count_before_scope},
+                {order, city_list_count_order},
+                {limit, CityListLimit}
+            ]}}
+    ],
+    bh_db_worker:load_from_eql(Conn, "cities.sql", Loads).
 
 handle('GET', [], Req) ->
-    Args = ?GET_ARGS([search, cursor], Req),
+    Args = ?GET_ARGS([search, order, cursor], Req),
     Result = get_city_list(Args),
     ?MK_RESPONSE(Result, block_time);
 handle('GET', [City, <<"hotspots">>], Req) ->
@@ -130,50 +83,59 @@ handle('GET', [City, <<"hotspots">>], Req) ->
 handle(_, _, _Req) ->
     ?RESPONSE_404.
 
-get_city_list([{search, undefined}, {cursor, undefined}]) ->
-    Result = ?PREPARED_QUERY(?S_CITY_LIST, []),
-    mk_city_list_from_result(undefined, Result);
-get_city_list([{search, Search}, {cursor, undefined}]) ->
+order_to_rank(<<"online_count">>) ->
+    <<"online_count">>;
+order_to_rank(<<"offline_count">>) ->
+    <<"offline_count">>;
+order_to_rank(<<"hotspot_count">>) ->
+    <<"hotspot_count">>;
+order_to_rank(_) ->
+    throw(?RESPONSE_400).
+
+get_city_list([{search, undefined}, {order, undefined}, {cursor, undefined}]) ->
+    Result = ?PREPARED_QUERY(?S_CITY_LIST_NAME, []),
+    mk_city_list_from_result(#{}, Result);
+get_city_list([{search, undefined}, {order, Order}, {cursor, undefined}]) ->
+    Rank = order_to_rank(Order),
+    Result = ?PREPARED_QUERY(?S_CITY_LIST_COUNT, [Rank]),
+    mk_city_list_from_result(#{order => Order}, Result);
+get_city_list([{search, Search}, {order, _}, {cursor, undefined}]) ->
     Result = ?PREPARED_QUERY(?S_CITY_SEARCH, [Search]),
-    mk_city_list_from_result(Search, Result);
-get_city_list([{search, _Search}, {cursor, Cursor}]) ->
+    mk_city_list_from_result(#{}, Result);
+get_city_list([{search, _}, {order, _}, {cursor, Cursor}]) ->
     case ?CURSOR_DECODE(Cursor) of
         {ok,
             #{
                 <<"city_id">> := CityId,
-                <<"rank">> := Rank
+                <<"rank">> := CursorRank
             } = C} ->
-            Search = maps:get(<<"search">>, C, undefined),
-            Result =
-                case Search of
-                    undefined ->
-                        ?PREPARED_QUERY(?S_CITY_LIST_BEFORE, [Rank, CityId]);
-                    Search ->
-                        ?PREPARED_QUERY(?S_CITY_SEARCH_BEFORE, [Search, Rank, CityId])
-                end,
-            mk_city_list_from_result(Search, Result);
+            case maps:get(<<"order">>, C, false) of
+                false ->
+                    Result = ?PREPARED_QUERY(?S_CITY_LIST_NAME_BEFORE, [CursorRank, CityId]),
+                    mk_city_list_from_result(#{}, Result);
+                Order ->
+                    Rank = order_to_rank(Order),
+                    Result = ?PREPARED_QUERY(?S_CITY_LIST_COUNT_BEFORE, [Rank, CursorRank, CityId]),
+                    mk_city_list_from_result(#{order => Order}, Result)
+            end;
         _ ->
             {error, badarg}
     end.
 
-mk_city_list_from_result(Search, {ok, _, Results}) ->
-    {ok, city_list_to_json(Results), mk_city_list_cursor(Search, Results)}.
+mk_city_list_from_result(CursorBase, {ok, _, Results}) ->
+    {ok, city_list_to_json(Results), mk_city_list_cursor(CursorBase, Results)}.
 
-mk_city_list_cursor(Search, Results) when is_list(Results) ->
+mk_city_list_cursor(CursorBase, Results) when is_list(Results) ->
     case length(Results) < ?CITY_LIST_LIMIT of
         true ->
             undefined;
         false ->
             {_ShortCity, _LongCity, _ShortState, _LongState, _ShortCountry, _LongCountry, CityId,
-                Rank, _Count} = lists:last(Results),
-            Base = #{
+                _TotalCount, _OnlineCount, _OfflineCount, Rank} = lists:last(Results),
+            CursorBase#{
                 city_id => CityId,
                 rank => Rank
-            },
-            case Search of
-                undefined -> Base;
-                _ -> Base#{search => Search}
-            end
+            }
     end.
 
 %%
@@ -184,11 +146,14 @@ city_list_to_json(Results) ->
     lists:map(fun city_to_json/1, Results).
 
 city_to_json(
-    {ShortCity, LongCity, ShortState, LongState, ShortCountry, LongCountry, CityId, _Rank, Count}
+    {ShortCity, LongCity, ShortState, LongState, ShortCountry, LongCountry, CityId, TotalCount,
+        OnlineCount, OfflineCount, _Rank}
 ) ->
     Base = bh_route_hotspots:to_geo_json(
         {ShortCity, LongCity, ShortState, LongState, ShortCountry, LongCountry, CityId}
     ),
     Base#{
-        hotspot_count => Count
+        hotspot_count => TotalCount,
+        online_count => OnlineCount,
+        offline_count => OfflineCount
     }.

--- a/test/bh_route_cities_SUITE.erl
+++ b/test/bh_route_cities_SUITE.erl
@@ -8,7 +8,8 @@
 
 all() ->
     [
-        city_list_test,
+        city_list_name_test,
+        city_list_count_test,
         city_search_test,
         city_hotspots_test,
         invalid_city_hotspots_test
@@ -20,8 +21,21 @@ init_per_suite(Config) ->
 end_per_suite(Config) ->
     ?end_bh(Config).
 
-city_list_test(_Config) ->
+city_list_name_test(_Config) ->
     {ok, {_, _, Json}} = ?json_request(["/v1/cities"]),
+    #{
+        <<"data">> := Data,
+        <<"cursor">> := Cursor
+    } = Json,
+    ?assert(length(Data) >= 0),
+
+    {ok, {_, _, NextJson}} = ?json_request(["/v1/cities?cursor=", Cursor]),
+    #{<<"data">> := NextData} = NextJson,
+    ?assert(length(NextData) >= 0),
+    ok.
+
+city_list_count_test(_Config) ->
+    {ok, {_, _, Json}} = ?json_request(["/v1/cities?order=hotspot_count"]),
     #{
         <<"data">> := Data,
         <<"cursor">> := Cursor


### PR DESCRIPTION
cities can be ordered by `online_count`, `offline_count`, `hotspot_count` , or long_city name by default.

For example: `/v1/cities?order=online_count` will return all cities with their online hotspot count in descending order

Fixes #207 