### PR TITLE
Calculate min block for transaction/activity list

### DIFF
--- a/src/bh_route_challenges.erl
+++ b/src/bh_route_challenges.erl
@@ -16,15 +16,13 @@ handle('GET', [], Req) ->
     Result = bh_route_txns:get_txn_list(Args),
     CacheTime = bh_route_txns:get_txn_list_cache_time(Result),
     ?MK_RESPONSE(Result, CacheTime);
-
 handle(_Method, _Path, _Req) ->
     ?RESPONSE_404.
-
 
 add_filter_types(Args) ->
     Args ++ [{filter_types, <<"poc_receipts_v1">>}].
 
-get_challenge_list({hotspot, Address}, Args=[{cursor, _}]) ->
-    bh_route_txns:get_actor_txn_list({actor, Address}, add_filter_types(Args));
-get_challenge_list({account, Address}, Args=[{cursor, _}]) ->
-    bh_route_txns:get_actor_txn_list({owned, Address}, add_filter_types(Args)).
+get_challenge_list({hotspot, Address}, Args = [{cursor, _}]) ->
+    bh_route_txns:get_actor_txn_list({hotspot, Address}, add_filter_types(Args));
+get_challenge_list({account, Address}, Args = [{cursor, _}]) ->
+    bh_route_txns:get_actor_txn_list({account, Address}, add_filter_types(Args)).

--- a/src/bh_route_elections.erl
+++ b/src/bh_route_elections.erl
@@ -16,14 +16,13 @@ handle('GET', [], Req) ->
     Result = bh_route_txns:get_txn_list(Args),
     CacheTime = bh_route_txns:get_txn_list_cache_time(Result),
     ?MK_RESPONSE(Result, CacheTime);
-
 handle(_Method, _Path, _Req) ->
     ?RESPONSE_404.
 
 add_filter_types(Args) ->
     Args ++ [{filter_types, <<"consensus_group_v1">>}].
 
-get_election_list({hotspot, Address}, Args=[{cursor, _}]) ->
-    bh_route_txns:get_actor_txn_list({actor, Address}, add_filter_types(Args));
-get_election_list({account, Address}, Args=[{cursor, _}]) ->
-    bh_route_txns:get_actor_txn_list({owned, Address}, add_filter_types(Args)).
+get_election_list({hotspot, Address}, Args = [{cursor, _}]) ->
+    bh_route_txns:get_actor_txn_list({hotspot, Address}, add_filter_types(Args));
+get_election_list({account, Address}, Args = [{cursor, _}]) ->
+    bh_route_txns:get_actor_txn_list({account, Address}, add_filter_types(Args)).

--- a/src/bh_route_oracle.erl
+++ b/src/bh_route_oracle.erl
@@ -56,7 +56,7 @@ handle('GET', [<<"activity">>], Req) ->
     ?MK_RESPONSE(Result, CacheTime);
 handle('GET', [Address, <<"activity">>], Req) ->
     Args = add_filter_types(?GET_ARGS([cursor], Req)),
-    Result = bh_route_txns:get_actor_txn_list({actor, Address}, Args),
+    Result = bh_route_txns:get_actor_txn_list({oracle, Address}, Args),
     CacheTime = bh_route_txns:get_txn_list_cache_time(Result),
     ?MK_RESPONSE(Result, CacheTime);
 handle(_, _, _Req) ->

--- a/test/bh_route_accounts_SUITE.erl
+++ b/test/bh_route_accounts_SUITE.erl
@@ -73,7 +73,10 @@ activity_result_test(_Config) ->
     ?assert(length(Data) =< ?TXN_LIST_LIMIT).
 
 activity_low_block_test(_Config) ->
-    GetCursor = #{block => 50},
+    GetCursor = #{
+        block => 50,
+        min_block => 1
+    },
     {ok, {_, _, Json}} = ?json_request(
         [
             "/v1/accounts/1122ZQigQfeeyfSmH2i4KM4XMQHouBqK4LsTp33ppP3W2Knqh8gY/activity",
@@ -91,6 +94,7 @@ activity_filter_no_result_test(_Config) ->
     %% so filtering for rewards should return no data.
     GetCursor = #{
         block => 50,
+        min_block => 1,
         types => <<"rewards_v1">>
     },
     {ok, {_, _, Json}} = ?json_request(

--- a/test/bh_route_hotspots_SUITE.erl
+++ b/test/bh_route_hotspots_SUITE.erl
@@ -117,7 +117,7 @@ activity_filter_no_result_test(_Config) ->
     %% Filter for no rewards, which the given hotspot should not have
     GetCursor = #{
         block => 50,
-        min_block => 1
+        min_block => 1,
         types => <<"rewards_v1">>
     },
     {ok, {_, _, Json}} = ?json_request(

--- a/test/bh_route_hotspots_SUITE.erl
+++ b/test/bh_route_hotspots_SUITE.erl
@@ -97,7 +97,10 @@ activity_result_test(_Config) ->
     ?assert(length(Data) =< ?TXN_LIST_LIMIT).
 
 activity_low_block_test(_Config) ->
-    GetCursor = #{block => 50},
+    GetCursor = #{
+        block => 50,
+        min_block => 1
+    },
     {ok, {_, _, Json}} = ?json_request(
         [
             "/v1/hotspots/112DCTVEbFi8azQ2KmhSDW2UqRM2ijmiMWKJptnhhPEk3uXvwLyK/activity",
@@ -114,6 +117,7 @@ activity_filter_no_result_test(_Config) ->
     %% Filter for no rewards, which the given hotspot should not have
     GetCursor = #{
         block => 50,
+        min_block => 1
         types => <<"rewards_v1">>
     },
     {ok, {_, _, Json}} = ?json_request(


### PR DESCRIPTION
Hotspot/account/oracle activity was searching all the way back to genesis block to try to get a full buffer of transactions to send back even if there were no more to be found. 

This fixes this by locating the earliest block the given actor had a transaction in and limiting the search to that