### PR TITLE
Fix cursor for activity list

### DIFF
--- a/src/bh_route_txns.erl
+++ b/src/bh_route_txns.erl
@@ -365,7 +365,7 @@ get_txn_count(Args, Query, [{filter_types, Types}]) ->
             Results
         )}.
 
-mk_txn_list_result(State = #state{results = Results}) when length(Results) > ?TXN_LIST_LIMIT ->
+mk_txn_list_result(State = #state{results = Results}) when length(Results) >= ?TXN_LIST_LIMIT ->
     {Trimmed, _Remainder} = lists:split(?TXN_LIST_LIMIT, Results),
     {Height, _Time, Hash, _Type, _Fields} = lists:last(Trimmed),
     {ok, txn_list_to_json(Trimmed), mk_txn_list_cursor(Height, Hash, State)};


### PR DESCRIPTION
This fixes activity lists skipping sequences of blocks. 

The bug was introducd when sql limit was used to limit the number of requested results. This caused cursor construction to use the wrong block height. 