### PR TITLE
Add oracle price stats

### DIFF
--- a/priv/oracles.sql
+++ b/priv/oracles.sql
@@ -8,3 +8,19 @@ order by p.block desc limit :limit
 select time, price 
 from oracle_price_predictions 
 order by time DESC
+
+-- :oracle_price_stats
+with price_data as (
+    select
+        p.price
+    from oracle_prices p inner join blocks b on p.block = b.height
+    where b.time >= extract(epoch from $1::timestamptz)
+    and b.time <= extract(epoch from $2::timestamptz)
+)
+select
+    coalesce(min(d.price) / 100000000, 0)::float as min,
+    coalesce(max(d.price) / 100000000, 0)::float as max,
+    coalesce(percentile_cont(0.5) within group (order by d.price) / 100000000, 0)::float as median,
+    coalesce(avg(d.price) / 100000000, 0)::float as avg,
+    coalesce(stddev(d.price) / 100000000, 0)::float as stddev
+from price_data d

--- a/test/bh_route_oracle_SUITE.erl
+++ b/test/bh_route_oracle_SUITE.erl
@@ -11,7 +11,8 @@ all() ->
         price_at_invalid_block_test,
         list_test,
         activity_list_test,
-        price_predictions_test
+        price_predictions_test,
+        price_stats_test
     ].
 
 init_per_suite(Config) ->
@@ -68,4 +69,10 @@ price_predictions_test(_Config) ->
     #{<<"data">> := AllData} = AllJson,
     ?assert(length(AllData) >= 0),
 
+    ok.
+
+price_stats_test(_Config) ->
+    {ok, {_, _, Json}} = ?json_request("/v1/oracle/prices/stats?min_time=-30%20day"),
+    #{<<"data">> := #{<<"max">> := Max}} = Json,
+    ?assert(Max >= 0),
     ok.


### PR DESCRIPTION
Returns oracle price statistics over a given min/max_time span 

```
http --body get localhost:8080/v1/oracle/prices/stats\?min_time=-30%20day
{
    "data": {
        "avg": 12.433719079615384,
        "max": 20.0,
        "median": 12.53731614,
        "min": 6.0,
        "stddev": 3.50807814
    },
    "meta": {
        "max_time": "2021-04-20T15:52:28Z",
        "min_time": "2021-03-21T15:52:28Z"
    }
}
```

Fixes: #201 