### PR TITLE
Get the block height that was valid at a given UTC time

### DIFF
--- a/src/bh_route_handler.erl
+++ b/src/bh_route_handler.erl
@@ -4,6 +4,7 @@
 
 -export([
     get_args/2,
+    parse_timestamp/1,
     parse_timespan/2,
     parse_bucket/2,
     parse_interval/1,
@@ -51,6 +52,11 @@ get_args([{Key, Default} | Tail], Req, Acc) ->
             Arg -> Arg
         end,
     get_args(Tail, Req, [{Key, V} | Acc]).
+
+
+-spec parse_timestamp(binary() | undefined) -> {ok, calendar:datetime()} | {error, term()}.
+parse_timestamp(Timestamp) ->
+    parse_timestamp(calendar:universal_time(), Timestamp).
 
 %% Parse a given binary timestamp. Returns the given `Now' time if passed
 %% <<"now">> or undefined. Otherwise an attempt is made to parse an interval relative

--- a/src/bh_route_handler.hrl
+++ b/src/bh_route_handler.hrl
@@ -15,6 +15,7 @@
 -define(PARSE_BUCKETED_TIMESPAN(H, L, B),
     bh_route_handler:parse_bucketed_timespan((H), (L), (B))
 ).
+-define(PARSE_TIMESTAMP(T), bh_route_handler:parse_timestamp((T))).
 -define(PARSE_FLOAT(F), bh_route_handler:parse_float((F))).
 -define(PARSE_INT(I), bh_route_handler:parse_int((I))).
 

--- a/test/bh_route_blocks_SUITE.erl
+++ b/test/bh_route_blocks_SUITE.erl
@@ -6,6 +6,7 @@
 all() ->
     [
         height_test,
+        height_by_time_test,
         block_for_height_test,
         block_for_invalid_height_test,
         block_for_height_txns_test,
@@ -24,6 +25,12 @@ end_per_suite(Config) ->
 
 height_test(_Config) ->
     {ok, {_, _, Json}} = ?json_request("/v1/blocks/height"),
+    ?assertMatch(#{<<"data">> := #{<<"height">> := _}}, Json),
+
+    ok.
+
+height_by_time_test(_Config) ->
+    {ok, {_, _, Json}} = ?json_request("/v1/blocks/height?max_time=2021-04-20"),
     ?assertMatch(#{<<"data">> := #{<<"height">> := _}}, Json),
 
     ok.


### PR DESCRIPTION
This adds a `?max_time` optional query argument for `/v1/blocks/height` to get the height of the chain at a given timestamp. 

e.g. 

```
http --body get localhost:8080/v1/blocks/height\?max_time=2021-03-01
{
    "data": {
        "height": 741318
    },
    "meta": {
        "max_time": "2021-03-01T00:00:00Z"
    }
}
```

Fixes #205 