### PR TITLE
Add speculative_nonce to single hotspot json

### DIFF
--- a/priv/hotspots.sql
+++ b/priv/hotspots.sql
@@ -34,6 +34,13 @@ order by g.first_block desc, g.address
 -- :hotspot_list_source
 from gateway_inventory g
 
+-- :hotspot_source
+, (select greatest(g.nonce, coalesce(max(p.nonce), g.nonce))
+    from pending_transactions p
+    where p.address = g.address and nonce_type = 'gateway' and status != 'failed'
+ ) as speculative_nonce
+ from gateway_inventory g
+
 -- :hotspot_list_before_scope
 where ((g.address > $1 and g.first_block = $2) or (g.first_block < $2))
 

--- a/src/bh_route_hotspots.erl
+++ b/src/bh_route_hotspots.erl
@@ -71,7 +71,7 @@ prepare_conn(Conn) ->
             ]}},
         {?S_HOTSPOT,
             {hotspot_list_base, [
-                {source, hotspot_list_source},
+                {source, hotspot_source},
                 {scope, "where g.address = $1"},
                 {order, ""},
                 {limit, ""}
@@ -562,6 +562,21 @@ hotspot_witness_to_json(
         witness_info => WitnessInfo
     }.
 
+hotspot_to_json(
+    {Height, LastChangeBlock, FirstBlock, FirstTimestamp, LastPoCChallenge, Address, Owner,
+        Location, Nonce, Name, RewardScale, Elevation, Gain, OnlineStatus, BlockStatus, ListenAddrs,
+        ShortStreet, LongStreet, ShortCity, LongCity, ShortState, LongState, ShortCountry,
+        LongCountry, CityId, SpecNonce}
+) ->
+    Base = hotspot_to_json(
+        {Height, LastChangeBlock, FirstBlock, FirstTimestamp, LastPoCChallenge, Address, Owner,
+            Location, Nonce, Name, RewardScale, Elevation, Gain, OnlineStatus, BlockStatus,
+            ListenAddrs, ShortStreet, LongStreet, ShortCity, LongCity, ShortState, LongState,
+            ShortCountry, LongCountry, CityId}
+    ),
+    Base#{
+        <<"speculative_nonce">> => SpecNonce
+    };
 hotspot_to_json(
     {Height, LastChangeBlock, FirstBlock, FirstTimestamp, LastPoCChallenge, Address, Owner,
         Location, Nonce, Name, RewardScale, Elevation, Gain, OnlineStatus, BlockStatus, ListenAddrs,


### PR DESCRIPTION
This adds a speculative_nonce  field to /v1/hotspots/:adddress

Fixes #253 