### PR TITLE
add /v1/hotspots/hex/:h3index

### DIFF
--- a/priv/hotspots.sql
+++ b/priv/hotspots.sql
@@ -54,12 +54,15 @@ where ((g.address > $2 and g.first_block = $3) or (g.first_block < $3))
 where l.city_id = $1
 and ((g.address > $2 and g.first_block = $3) or (g.first_block < $3))
 
--- :city_hotspot_list_before_scope
-where l.city_id = $1
-and ((g.address > $2 and g.first_block = $3) or (g.first_block < $3))
-
 -- :city_hotspot_list_scope
 where l.city_id = $1
+
+-- :hex_hotspot_list_scope
+where g.location_hex = $1
+
+-- :hex_hotspot_list_before_scope
+where g.location_hex = $1
+and ((g.address > $2 and g.first_block = $3) or (g.first_block < $3))
 
 -- :hotspot_name_search_source
 from gateway_inventory g

--- a/test/bh_route_hotspots_SUITE.erl
+++ b/test/bh_route_hotspots_SUITE.erl
@@ -30,7 +30,8 @@ all() ->
         name_test,
         name_search_test,
         location_distance_search_test,
-        location_box_search_test
+        location_box_search_test,
+        location_hex_test
     ].
 
 init_per_suite(Config) ->
@@ -369,4 +370,14 @@ location_box_search_test(_Config) ->
         <<"data">> := CursorResults
     } = CursorJson,
     ?assert(length(CursorResults) >= 1),
+    ok.
+
+location_hex_test(_Config) ->
+    %% San Francisco should have a few in res 8
+    FetchLocation = "88283082a3fffff",
+    {ok, {_, _, Json}} = ?json_request(["/v1/hotspots/hex/", FetchLocation]),
+    #{
+        <<"data">> := Results
+    } = Json,
+    ?assert(length(Results) >= 1),
     ok.


### PR DESCRIPTION
This adds a lookup for all hotspots in a given h3 index. 

**NOTE** only resolution 8 is supported 

Requires https://github.com/helium/blockchain-etl/pull/169 to be deployed