### PR TITLE
use actor table only for PoC witness list

### DIFF
--- a/src/bh_route_hotspots.erl
+++ b/src/bh_route_hotspots.erl
@@ -564,7 +564,7 @@ hotspot_list_to_json(Results) ->
     lists:map(fun hotspot_to_json/1, Results).
 
 hotspot_witness_list_to_json(Results) ->
-    lists:map(fun hotspot_witness_to_json/1, Results).
+    lists:map(fun hotspot_to_json/1, Results).
 
 to_geo_json(
     {ShortStreet, LongStreet, ShortCity, LongCity, ShortState, LongState, ShortCountry, LongCountry,
@@ -592,23 +592,6 @@ to_geo_json(
         short_country => ShortCountry,
         long_country => LongCountry,
         city_id => MaybeB64(CityId)
-    }.
-
-hotspot_witness_to_json(
-    {Height, LastChangeBlock, FirstBlock, FirstTimestamp, LastPoCChallenge, Address, Mode, Owner,
-        Location, Nonce, Name, RewardScale, Elevation, Gain, OnlineStatus, BlockStatus, ListenAddrs,
-        ShortStreet, LongStreet, ShortCity, LongCity, ShortState, LongState, ShortCountry,
-        LongCountry, CityId, WitnessFor, WitnessInfo}
-) ->
-    Base = hotspot_to_json(
-        {Height, LastChangeBlock, FirstBlock, FirstTimestamp, LastPoCChallenge, Address, Mode,
-            Owner, Location, Nonce, Name, RewardScale, Elevation, Gain, OnlineStatus, BlockStatus,
-            ListenAddrs, ShortStreet, LongStreet, ShortCity, LongCity, ShortState, LongState,
-            ShortCountry, LongCountry, CityId}
-    ),
-    Base#{
-        witness_for => WitnessFor,
-        witness_info => WitnessInfo
     }.
 
 hotspot_to_json(


### PR DESCRIPTION
The ledger information is not tied to the witness time interval being requested so the ledger data was not accurate.

The side effect is what `witness_info` including the rssi table is lost in the witness list (since it was not accurate at all in its counts for the requested block range)