### PR TITLE
Adds dc_burns sum route

### DIFF
--- a/priv/dc_burns.sql
+++ b/priv/dc_burns.sql
@@ -32,3 +32,40 @@ union
 select 'last_week', t.type, sum(t.amount)::bigint from week_interval t group by t.type
 union
 select 'last_month', t.type, sum(t.amount)::bigint from month_interval t group by t.type;
+
+
+-- :burn_sum
+select d.type, sum(d.amount) as amount
+from dc_burns d 
+where d.time >= extract(epoch from $1::timestamptz)
+    and d.time <= extract(epoch from $2::timestamptz)
+group by d.type;
+
+-- :burn_bucketed_sum
+with time_range as (
+    select
+        extract(epoch from low)::bigint as low,
+        extract(epoch from high)::bigint as high
+    from (
+        select
+            timestamp as low,
+            lag(timestamp) over (order by timestamp desc) as high
+        from generate_series($1::timestamptz, $2::timestamptz, $3::interval) as timestamp) t
+    where high is not null
+),
+burn_data as (
+    select sum(d.amount) as amount, d.time, d.type
+    from dc_burns d 
+    where d.time >= (select min(low) from time_range) 
+        and d.time <= (select max(high) from time_range)
+    group by d.time, d.type    
+)
+select 
+    t.low, 
+    d.type, 
+    sum(d.amount)::bigint 
+from time_range t
+    left join burn_data d
+    on  d.time >= low and d.time < high
+group by t.low, d.type
+order by t.low desc;

--- a/test/bh_route_dc_burns_SUITE.erl
+++ b/test/bh_route_dc_burns_SUITE.erl
@@ -7,7 +7,9 @@
 all() ->
     [
         list_test,
-        stats_test
+        stats_test,
+        sum_test,
+        bucket_sum_test
     ].
 
 init_per_suite(Config) ->
@@ -37,4 +39,20 @@ stats_test(_Config) ->
     {ok, {_, _, Json}} = ?json_request("/v1/dc_burns/stats"),
     #{<<"data">> := #{<<"last_day">> := Value}} = Json,
     ?assert(Value >= 0),
+    ok.
+
+sum_test(_Config) ->
+    {ok, {_, _, Json}} =
+        ?json_request(["/v1/dc_burns/sum?min_time=-2%20day"]),
+    #{<<"data">> := Data} = Json,
+    ?assert(maps:size(Data) > 0),
+
+    ok.
+
+bucket_sum_test(_Config) ->
+    {ok, {_, _, Json}} =
+        ?json_request(["/v1/dc_burns/sum?min_time=-7%20day&bucket=day"]),
+    #{<<"data">> := Data} = Json,
+    ?assertEqual(7, length(Data)),
+
     ok.


### PR DESCRIPTION
Adds a `v1/dc_burns/sum` route which can take both bucket and non-bucket time ranges to deliver totals, or bucketed totals for dc_burns

Fixes #275 