### PR TITLE
Fix challenges sum

### DIFF
--- a/src/bh_route_hotspots.erl
+++ b/src/bh_route_hotspots.erl
@@ -187,7 +187,8 @@ prepare_conn(Conn) ->
             ]}},
         {?S_HOTSPOT_BUCKETED_SUM_CHALLENGES,
             {hotspot_bucketed_challenges_base, [
-                {scope, "where a.actor = $1"},
+                {scope,
+                    "where a.actor = $1 and a.actor_role = ANY('{challenger, challengee, witness}')"},
                 {source, hotspot_bucketed_challenges_source}
             ]}}
     ],


### PR DESCRIPTION
Fixes challenges (bucketed) sum  to only include transactions where the hotspot was a challenger, challengee or witness.

Fixes: #280 