### PR TITLE
Add state_channels endpoint

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -33,6 +33,7 @@
             bh_route_ouis,
             bh_route_locations,
             bh_route_dc_burns,
+            bh_route_state_channels,
             bh_route_validators
         ]},
         {db_rw_handlers, [

--- a/priv/state_channels.sql
+++ b/priv/state_channels.sql
@@ -1,0 +1,14 @@
+-- Get currently active and last day state_channel count
+-- :state_channels_stats
+with block_last_day_range as (
+    select min(height), max(height) from blocks
+    where timestamp between now() - '24 hour'::interval and now()
+),
+last_day_state_channels as (
+    select hash from transactions
+    where block between (select min from block_last_day_range) and (select max from block_last_day_range)
+          and type = 'state_channel_close_v1'
+)
+select * from
+    (select count(*) as last_day_state_channels from last_day_state_channels) as last_day
+

--- a/src/bh_route_state_channels.erl
+++ b/src/bh_route_state_channels.erl
@@ -1,0 +1,48 @@
+-module(bh_route_state_channels).
+
+-export([prepare_conn/1, handle/3]).
+-export([get_state_channel_stats/0]).
+
+-behavior(bh_route_handler).
+-behavior(bh_db_worker).
+
+-include("bh_route_handler.hrl").
+
+-define(S_STATE_CHANNEL_STATS, "state_channels_stats").
+
+prepare_conn(Conn) ->
+    Loads = [?S_STATE_CHANNEL_STATS],
+    bh_db_worker:load_from_eql(Conn, "state_channels.sql", Loads).
+
+handle('GET', [], Req) ->
+    Args = add_filter_types(?GET_ARGS([cursor], Req)),
+    Result = bh_route_txns:get_txn_list(Args),
+    CacheTime = bh_route_txns:get_txn_list_cache_time(Result),
+    ?MK_RESPONSE(Result, CacheTime);
+handle('GET', [<<"stats">>], _Req) ->
+    ?MK_RESPONSE(
+        {ok,
+            mk_stats_from_state_channel_results(
+                get_state_channel_stats()
+            )},
+        block_time
+    );
+handle(_Method, _Path, _Req) ->
+    ?RESPONSE_404.
+
+add_filter_types(Args) ->
+    Args ++ [{filter_types, <<"state_channel_close_v1">>}].
+
+get_state_channel_stats() ->
+    bh_cache:get(
+        {?MODULE, state_channel_stats},
+        fun() ->
+            {ok, _Columns, Data} = ?PREPARED_QUERY(?S_STATE_CHANNEL_STATS, []),
+            Data
+        end
+    ).
+
+mk_stats_from_state_channel_results({ok, [{LastDayChallenges}]}) ->
+    #{
+        last_day => ?PARSE_INT(LastDayChallenges)
+    }.

--- a/src/bh_routes.erl
+++ b/src/bh_routes.erl
@@ -44,6 +44,8 @@ handle(Method, [<<"v1">>, <<"rewards">> | Tail], Req) ->
     bh_route_rewards:handle(Method, Tail, Req);
 handle(Method, [<<"v1">>, <<"dc_burns">> | Tail], Req) ->
     bh_route_dc_burns:handle(Method, Tail, Req);
+handle(Method, [<<"v1">>, <<"state_channels">> | Tail], Req) ->
+    bh_route_state_channels:handle(Method, Tail, Req);
 handle(Method, [<<"v1">>, <<"validators">> | Tail], Req) ->
     bh_route_validators:handle(Method, Tail, Req);
 handle('GET', [], _Req) ->

--- a/test/bh_route_state_channels_SUITE.erl
+++ b/test/bh_route_state_channels_SUITE.erl
@@ -36,5 +36,6 @@ list_test(_Config) ->
 
 stats_test(_Config) ->
     {ok, {_, _, Json}} = ?json_request("/v1/state_channels/stats"),
-    #{<<"data">> := Txns} = Json,
-    ?assert(length(Txns) >= 0).
+    #{<<"data">> := #{<<"last_day">> := Value}} = Json,
+    ?assert(Value >= 0),
+    ok.

--- a/test/bh_route_state_channels_SUITE.erl
+++ b/test/bh_route_state_channels_SUITE.erl
@@ -1,0 +1,40 @@
+-module(bh_route_state_channels_SUITE).
+-compile([nowarn_export_all, export_all]).
+
+-include("ct_utils.hrl").
+-include("../src/bh_route_handler.hrl").
+
+all() ->
+    [
+        list_test,
+        stats_test
+    ].
+
+init_per_suite(Config) ->
+    ?init_bh(Config).
+
+end_per_suite(Config) ->
+    ?end_bh(Config).
+
+list_test(_Config) ->
+    {ok, {_, _, FirstJson}} = ?json_request("/v1/state_channels"),
+    #{
+        <<"data">> := FirstTxns,
+        <<"cursor">> := Cursor
+    } = FirstJson,
+
+    ?assert(length(FirstTxns) =< ?TXN_LIST_LIMIT),
+
+    {ok, {_, _, NextJson}} = ?json_request(["/v1/state_channels?cursor=", Cursor]),
+    #{
+        <<"data">> := NextTxns,
+        <<"cursor">> := _
+    } = NextJson,
+    ?assert(length(NextTxns) =< ?TXN_LIST_LIMIT),
+
+    ok.
+
+stats_test(_Config) ->
+    {ok, {_, _, Json}} = ?json_request("/v1/state_channels/stats"),
+    #{<<"data">> := Txns} = Json,
+    ?assert(length(Txns) >= 0).


### PR DESCRIPTION
Adds:

* `/v1/state_channels` to list state channel close transaction in descending block order. The results are paginated with a cursor
* `/v1/state_channels/stats` gets the state channels closed in the last 24 hours as a first stat for state channels


Fixes #292 