### PR TITLE
Reverse city name search order by rank

### DIFF
--- a/priv/cities.sql
+++ b/priv/cities.sql
@@ -65,7 +65,7 @@ d.long_city as rank
 where rank >= $1 and city_id > $2
 
 -- :city_search_order
-order by rank, city_id
+order by rank desc, city_id
 
 -- :city_search_rank
 word_similarity(d.long_city, $1) as rank


### PR DESCRIPTION
word similarity goes up when a closer match so list the highest rank first.

 Fixes: #309 
Requires: https://github.com/helium/blockchain-etl/pull/220 to get the city search index fixed up