### PR TITLE
Add limit request parameter to activity / txn list routes

### DIFF
--- a/src/bh_route_accounts.erl
+++ b/src/bh_route_accounts.erl
@@ -79,7 +79,7 @@ handle('GET', [Account, <<"validators">>], Req) ->
         block_time
     );
 handle('GET', [Account, <<"activity">>], Req) ->
-    Args = ?GET_ARGS([cursor, filter_types], Req),
+    Args = ?GET_ARGS([cursor, limit, filter_types], Req),
     Result = bh_route_txns:get_activity_list({account, Account}, Args),
     CacheTime = bh_route_txns:get_txn_list_cache_time(Result),
     ?MK_RESPONSE(Result, CacheTime);
@@ -87,13 +87,13 @@ handle('GET', [Account, <<"activity">>, <<"count">>], Req) ->
     Args = ?GET_ARGS([filter_types], Req),
     ?MK_RESPONSE(bh_route_txns:get_activity_count({account, Account}, Args), block_time);
 handle('GET', [Account, <<"elections">>], Req) ->
-    Args = ?GET_ARGS([cursor], Req),
+    Args = ?GET_ARGS([cursor, limit], Req),
     ?MK_RESPONSE(
         bh_route_elections:get_election_list({account, Account}, Args),
         block_time
     );
 handle('GET', [Account, <<"challenges">>], Req) ->
-    Args = ?GET_ARGS([cursor], Req),
+    Args = ?GET_ARGS([cursor, limit], Req),
     ?MK_RESPONSE(
         bh_route_challenges:get_challenge_list({account, Account}, Args),
         block_time

--- a/src/bh_route_assert_locations.erl
+++ b/src/bh_route_assert_locations.erl
@@ -11,7 +11,7 @@ prepare_conn(_Conn) ->
     #{}.
 
 handle('GET', [], Req) ->
-    Args = add_filter_types(?GET_ARGS([cursor], Req)),
+    Args = add_filter_types(?GET_ARGS([cursor, limit], Req)),
     Result = bh_route_txns:get_txn_list(Args),
     CacheTime = bh_route_txns:get_txn_list_cache_time(Result),
     ?MK_RESPONSE(Result, CacheTime);

--- a/src/bh_route_challenges.erl
+++ b/src/bh_route_challenges.erl
@@ -2,9 +2,9 @@
 
 -export([prepare_conn/1, handle/3]).
 -export([
-         get_challenge_list/2,
-         get_challenge_stats/0
-        ]).
+    get_challenge_list/2,
+    get_challenge_stats/0
+]).
 
 -behavior(bh_route_handler).
 -behavior(bh_db_worker).
@@ -18,27 +18,34 @@ prepare_conn(Conn) ->
     bh_db_worker:load_from_eql(Conn, "challenges.sql", Loads).
 
 handle('GET', [], Req) ->
-    Args = add_filter_types(?GET_ARGS([cursor], Req)),
+    Args = add_filter_types(?GET_ARGS([cursor, limit], Req)),
     Result = bh_route_txns:get_txn_list(Args),
     CacheTime = bh_route_txns:get_txn_list_cache_time(Result),
     ?MK_RESPONSE(Result, CacheTime);
 handle('GET', [<<"stats">>], _Req) ->
-    ?MK_RESPONSE({ok, bh_route_stats:mk_stats_from_challenge_results(
-                   get_challenge_stats())}, block_time);
+    ?MK_RESPONSE(
+        {ok,
+            bh_route_stats:mk_stats_from_challenge_results(
+                get_challenge_stats()
+            )},
+        block_time
+    );
 handle(_Method, _Path, _Req) ->
     ?RESPONSE_404.
 
 add_filter_types(Args) ->
     Args ++ [{filter_types, <<"poc_receipts_v1">>}].
 
-get_challenge_list({hotspot, Address}, Args = [{cursor, _}]) ->
+get_challenge_list({hotspot, Address}, Args) ->
     bh_route_txns:get_actor_txn_list({hotspot, Address}, add_filter_types(Args));
-get_challenge_list({account, Address}, Args = [{cursor, _}]) ->
+get_challenge_list({account, Address}, Args) ->
     bh_route_txns:get_actor_txn_list({account, Address}, add_filter_types(Args)).
 
 get_challenge_stats() ->
-    bh_cache:get({?MODULE, challenge_stats},
-                 fun() ->
-                         {ok, _Columns, Data} = ?PREPARED_QUERY(?S_CHALLENGE_STATS, []),
-                         Data
-                 end).
+    bh_cache:get(
+        {?MODULE, challenge_stats},
+        fun() ->
+            {ok, _Columns, Data} = ?PREPARED_QUERY(?S_CHALLENGE_STATS, []),
+            Data
+        end
+    ).

--- a/src/bh_route_elections.erl
+++ b/src/bh_route_elections.erl
@@ -2,9 +2,9 @@
 
 -export([prepare_conn/1, handle/3]).
 -export([
-         get_election_list/2,
-         get_election_time_stats/0
-        ]).
+    get_election_list/2,
+    get_election_time_stats/0
+]).
 
 -behavior(bh_route_handler).
 -behavior(bh_db_worker).
@@ -18,27 +18,34 @@ prepare_conn(Conn) ->
     bh_db_worker:load_from_eql(Conn, "elections.sql", Loads).
 
 handle('GET', [], Req) ->
-    Args = add_filter_types(?GET_ARGS([cursor], Req)),
+    Args = add_filter_types(?GET_ARGS([cursor, limit], Req)),
     Result = bh_route_txns:get_txn_list(Args),
     CacheTime = bh_route_txns:get_txn_list_cache_time(Result),
     ?MK_RESPONSE(Result, CacheTime);
 handle('GET', [<<"stats">>], _Req) ->
-    ?MK_RESPONSE({ok, bh_route_stats:mk_stats_from_time_results(
-                   get_election_time_stats())}, block_time);
+    ?MK_RESPONSE(
+        {ok,
+            bh_route_stats:mk_stats_from_time_results(
+                get_election_time_stats()
+            )},
+        block_time
+    );
 handle(_Method, _Path, _Req) ->
     ?RESPONSE_404.
 
 add_filter_types(Args) ->
     Args ++ [{filter_types, <<"consensus_group_v1">>}].
 
-get_election_list({hotspot, Address}, Args = [{cursor, _}]) ->
+get_election_list({hotspot, Address}, Args) ->
     bh_route_txns:get_actor_txn_list({hotspot, Address}, add_filter_types(Args));
-get_election_list({account, Address}, Args = [{cursor, _}]) ->
+get_election_list({account, Address}, Args) ->
     bh_route_txns:get_actor_txn_list({account, Address}, add_filter_types(Args)).
 
 get_election_time_stats() ->
-    bh_cache:get({?MODULE, election_time_stats},
-                 fun() ->
-                         {ok, _Columns, Data} = ?PREPARED_QUERY(?S_ELECTION_TIMES, []),
-                         Data
-                 end).
+    bh_cache:get(
+        {?MODULE, election_time_stats},
+        fun() ->
+            {ok, _Columns, Data} = ?PREPARED_QUERY(?S_ELECTION_TIMES, []),
+            Data
+        end
+    ).

--- a/src/bh_route_hotspots.erl
+++ b/src/bh_route_hotspots.erl
@@ -245,7 +245,7 @@ handle('GET', [<<"hex">>, Location], Req) ->
     Args = ?GET_ARGS([cursor], Req),
     ?MK_RESPONSE(get_hotspot_list([{location_hex, Location}] ++ Args), block_time);
 handle('GET', [Address, <<"activity">>], Req) ->
-    Args = ?GET_ARGS([cursor, filter_types], Req),
+    Args = ?GET_ARGS([cursor, limit, filter_types], Req),
     Result = bh_route_txns:get_activity_list({hotspot, Address}, Args),
     CacheTime = bh_route_txns:get_txn_list_cache_time(Result),
     ?MK_RESPONSE(Result, CacheTime);
@@ -253,13 +253,13 @@ handle('GET', [Address, <<"activity">>, <<"count">>], Req) ->
     Args = ?GET_ARGS([filter_types], Req),
     ?MK_RESPONSE(bh_route_txns:get_activity_count({hotspot, Address}, Args), block_time);
 handle('GET', [Address, <<"elections">>], Req) ->
-    Args = ?GET_ARGS([cursor], Req),
+    Args = ?GET_ARGS([cursor, limit], Req),
     ?MK_RESPONSE(
         bh_route_elections:get_election_list({hotspot, Address}, Args),
         block_time
     );
 handle('GET', [Address, <<"challenges">>], Req) ->
-    Args = ?GET_ARGS([cursor], Req),
+    Args = ?GET_ARGS([cursor, limit], Req),
     ?MK_RESPONSE(
         bh_route_challenges:get_challenge_list({hotspot, Address}, Args),
         block_time

--- a/src/bh_route_oracle.erl
+++ b/src/bh_route_oracle.erl
@@ -57,12 +57,12 @@ handle('GET', [<<"prices">>, Block], _Req) ->
 handle('GET', [<<"predictions">>], _Req) ->
     ?MK_RESPONSE(get_price_predictions(), block_time);
 handle('GET', [<<"activity">>], Req) ->
-    Args = add_filter_types(?GET_ARGS([cursor], Req)),
+    Args = add_filter_types(?GET_ARGS([cursor, limit], Req)),
     Result = bh_route_txns:get_txn_list(Args),
     CacheTime = bh_route_txns:get_txn_list_cache_time(Result),
     ?MK_RESPONSE(Result, CacheTime);
 handle('GET', [Address, <<"activity">>], Req) ->
-    Args = add_filter_types(?GET_ARGS([cursor], Req)),
+    Args = add_filter_types(?GET_ARGS([cursor, limit], Req)),
     Result = bh_route_txns:get_actor_txn_list({oracle, Address}, Args),
     CacheTime = bh_route_txns:get_txn_list_cache_time(Result),
     ?MK_RESPONSE(Result, CacheTime);

--- a/src/bh_route_state_channels.erl
+++ b/src/bh_route_state_channels.erl
@@ -15,7 +15,7 @@ prepare_conn(Conn) ->
     bh_db_worker:load_from_eql(Conn, "state_channels.sql", Loads).
 
 handle('GET', [], Req) ->
-    Args = add_filter_types(?GET_ARGS([cursor], Req)),
+    Args = add_filter_types(?GET_ARGS([cursor, limit], Req)),
     Result = bh_route_txns:get_txn_list(Args, ?STATE_CHANNEL_TXN_LIST_LIMIT),
     CacheTime = bh_route_txns:get_txn_list_cache_time(Result),
     ?MK_RESPONSE(Result, CacheTime);

--- a/src/bh_route_validators.erl
+++ b/src/bh_route_validators.erl
@@ -132,7 +132,7 @@ handle('GET', [<<"name">>, Name], _Req) ->
 handle('GET', [Address], _Req) ->
     ?MK_RESPONSE(get_validator(Address), never);
 handle('GET', [Address, <<"activity">>], Req) ->
-    Args = ?GET_ARGS([cursor, filter_types], Req),
+    Args = ?GET_ARGS([cursor, limit, filter_types], Req),
     Result = bh_route_txns:get_activity_list({validator, Address}, Args),
     CacheTime = bh_route_txns:get_txn_list_cache_time(Result),
     ?MK_RESPONSE(Result, CacheTime);

--- a/src/bh_route_vars.erl
+++ b/src/bh_route_vars.erl
@@ -26,7 +26,7 @@ prepare_conn(Conn) ->
 handle('GET', [], _Req) ->
     ?MK_RESPONSE(get_var_list(), block_time);
 handle('GET', [<<"activity">>], Req) ->
-    Args = add_filter_types(?GET_ARGS([cursor], Req)),
+    Args = add_filter_types(?GET_ARGS([cursor, limit], Req)),
     Result = bh_route_txns:get_txn_list(Args),
     CacheTime = bh_route_txns:get_txn_list_cache_time(Result),
     ?MK_RESPONSE(Result, CacheTime);

--- a/test/bh_route_hotspots_SUITE.erl
+++ b/test/bh_route_hotspots_SUITE.erl
@@ -89,14 +89,17 @@ activity_result_test(_Config) ->
     %% returned. Expect a maybe empty array with a start and end block
     %% and a cursor to a next block range
     {ok, {_, _, Json}} = ?json_request(
-        "/v1/hotspots/112DCTVEbFi8azQ2KmhSDW2UqRM2ijmiMWKJptnhhPEk3uXvwLyK/activity"
+        [
+            "/v1/hotspots/112DCTVEbFi8azQ2KmhSDW2UqRM2ijmiMWKJptnhhPEk3uXvwLyK/activity",
+            "?limit=5"
+        ]
     ),
     #{
         <<"data">> := Data,
         <<"cursor">> := Cursor
     } = Json,
     {ok, #{<<"block">> := _}} = ?CURSOR_DECODE(Cursor),
-    ?assert(length(Data) =< ?TXN_LIST_LIMIT).
+    ?assert(length(Data) =< 5).
 
 activity_low_block_test(_Config) ->
     GetCursor = #{


### PR DESCRIPTION
Adds limit query param support for activity/txn list routes in

-  vars (all_activity)
- validators (activity)
- oracle (activity, all_activity)
- hotspots (activity, elections, challenges)
- accounts (activity, challenges, elections)
- assert_locations
- challenges
- elections
- state_channels

Part of improving: #311 