### PR TITLE
Adds min_time, max_time support  to all activity / txn list routes

### DIFF
--- a/priv/blocks.sql
+++ b/priv/blocks.sql
@@ -1,3 +1,13 @@
+-- :block_span
+with max as (
+     select height from blocks where timestamp <= $1 order by timestamp desc limit 1
+),
+min as (
+    select height from blocks where timestamp >= $2 order by timestamp limit 1
+)
+select (select height from max) as max, (select height from min) as min
+
+
 -- Get block stats
 -- :block_times
 with month_interval as (

--- a/priv/rewards.sql
+++ b/priv/rewards.sql
@@ -1,12 +1,3 @@
--- :reward_block_range
-with max as (
-     select height from blocks where timestamp <= $1 order by timestamp desc limit 1
-),
-min as (
-    select height from blocks where timestamp >= $2 order by timestamp limit 1
-)
-select (select height from max) as max, (select height from min) as min
-
 -- :reward_fields
 r.block, r.transaction_hash, to_timestamp(r.time) as timestamp, r.account, r.gateway, r.amount
 

--- a/src/bh_route_accounts.erl
+++ b/src/bh_route_accounts.erl
@@ -79,7 +79,7 @@ handle('GET', [Account, <<"validators">>], Req) ->
         block_time
     );
 handle('GET', [Account, <<"activity">>], Req) ->
-    Args = ?GET_ARGS([cursor, limit, filter_types], Req),
+    Args = ?GET_ARGS([cursor, max_time, min_time, limit, filter_types], Req),
     Result = bh_route_txns:get_activity_list({account, Account}, Args),
     CacheTime = bh_route_txns:get_txn_list_cache_time(Result),
     ?MK_RESPONSE(Result, CacheTime);
@@ -87,13 +87,13 @@ handle('GET', [Account, <<"activity">>, <<"count">>], Req) ->
     Args = ?GET_ARGS([filter_types], Req),
     ?MK_RESPONSE(bh_route_txns:get_activity_count({account, Account}, Args), block_time);
 handle('GET', [Account, <<"elections">>], Req) ->
-    Args = ?GET_ARGS([cursor, limit], Req),
+    Args = ?GET_ARGS([cursor, max_time, min_time, limit], Req),
     ?MK_RESPONSE(
         bh_route_elections:get_election_list({account, Account}, Args),
         block_time
     );
 handle('GET', [Account, <<"challenges">>], Req) ->
-    Args = ?GET_ARGS([cursor, limit], Req),
+    Args = ?GET_ARGS([cursor, max_time, min_time, limit], Req),
     ?MK_RESPONSE(
         bh_route_challenges:get_challenge_list({account, Account}, Args),
         block_time

--- a/src/bh_route_assert_locations.erl
+++ b/src/bh_route_assert_locations.erl
@@ -11,7 +11,7 @@ prepare_conn(_Conn) ->
     #{}.
 
 handle('GET', [], Req) ->
-    Args = add_filter_types(?GET_ARGS([cursor, limit], Req)),
+    Args = add_filter_types(?GET_ARGS([cursor, max_time, min_time, limit], Req)),
     Result = bh_route_txns:get_txn_list(Args),
     CacheTime = bh_route_txns:get_txn_list_cache_time(Result),
     ?MK_RESPONSE(Result, CacheTime);

--- a/src/bh_route_blocks.erl
+++ b/src/bh_route_blocks.erl
@@ -202,7 +202,7 @@ handle('GET', [BlockId, <<"transactions">>], Req) ->
 handle(_Method, _Path, _Req) ->
     ?RESPONSE_404.
 
--spec get_block_span(High :: binary(), Low :: binary()) ->
+-spec get_block_span(High :: binary() | undefined, Low :: binary() | undefined) ->
     {ok, {bh_route_handler:timespan(), bh_route_handler:blockspan()}}
     | {error, term()}.
 get_block_span(MaxTime0, MinTime0) ->

--- a/src/bh_route_blocks.erl
+++ b/src/bh_route_blocks.erl
@@ -14,7 +14,8 @@
     get_block_list_cache_time/1,
     get_block/1,
     get_block_txn_list/2,
-    get_block_stats/0
+    get_block_stats/0,
+    get_block_span/2
 ]).
 
 -define(S_BLOCK_HEIGHT, "block_height").
@@ -22,6 +23,7 @@
 
 -define(S_BLOCK_LIST_BEFORE, "block_list_before").
 
+-define(S_BLOCK_SPAN, "block_span").
 -define(S_BLOCK_BY_HASH, "block_by_hash").
 -define(S_BLOCK_BY_HEIGHT, "block_by_height").
 -define(S_BLOCK_HEIGHT_TXN_LIST, "block_height_txn_list").
@@ -139,7 +141,10 @@ prepare_conn(Conn) ->
         []
     ),
 
-    M = bh_db_worker:load_from_eql(Conn, "blocks.sql", [?S_BLOCK_TIMES]),
+    M = bh_db_worker:load_from_eql(Conn, "blocks.sql", [
+        ?S_BLOCK_TIMES,
+        ?S_BLOCK_SPAN
+    ]),
 
     maps:merge(
         #{
@@ -196,6 +201,19 @@ handle('GET', [BlockId, <<"transactions">>], Req) ->
     );
 handle(_Method, _Path, _Req) ->
     ?RESPONSE_404.
+
+-spec get_block_span(High :: binary(), Low :: binary()) ->
+    {ok, {bh_route_handler:timespan(), bh_route_handler:blockspan()}}
+    | {error, term()}.
+get_block_span(MaxTime0, MinTime0) ->
+    case ?PARSE_TIMESPAN(MaxTime0, MinTime0) of
+        {ok, {MaxTime, MinTime}} ->
+            {ok, _, [{HighBlock, LowBlock}]} =
+                ?PREPARED_QUERY(?S_BLOCK_SPAN, [MaxTime, MinTime]),
+            {ok, {{MaxTime, MinTime}, {HighBlock, LowBlock}}};
+        {error, Error} ->
+            {error, Error}
+    end.
 
 get_block_list([{cursor, undefined}]) ->
     {ok, #{height := Height}} = get_block_height(),

--- a/src/bh_route_challenges.erl
+++ b/src/bh_route_challenges.erl
@@ -18,7 +18,7 @@ prepare_conn(Conn) ->
     bh_db_worker:load_from_eql(Conn, "challenges.sql", Loads).
 
 handle('GET', [], Req) ->
-    Args = add_filter_types(?GET_ARGS([cursor, limit], Req)),
+    Args = add_filter_types(?GET_ARGS([cursor, max_time, min_time, limit], Req)),
     Result = bh_route_txns:get_txn_list(Args),
     CacheTime = bh_route_txns:get_txn_list_cache_time(Result),
     ?MK_RESPONSE(Result, CacheTime);

--- a/src/bh_route_elections.erl
+++ b/src/bh_route_elections.erl
@@ -18,7 +18,7 @@ prepare_conn(Conn) ->
     bh_db_worker:load_from_eql(Conn, "elections.sql", Loads).
 
 handle('GET', [], Req) ->
-    Args = add_filter_types(?GET_ARGS([cursor, limit], Req)),
+    Args = add_filter_types(?GET_ARGS([cursor, max_time, min_time, limit], Req)),
     Result = bh_route_txns:get_txn_list(Args),
     CacheTime = bh_route_txns:get_txn_list_cache_time(Result),
     ?MK_RESPONSE(Result, CacheTime);

--- a/src/bh_route_handler.erl
+++ b/src/bh_route_handler.erl
@@ -91,7 +91,8 @@ parse_timestamp(Now, Bin) ->
             end
     end.
 
--spec parse_timespan(High :: binary(), Low :: binary()) -> {ok, timespan()} | {error, term()}.
+-spec parse_timespan(High :: binary() | undefined, Low :: binary() | undefined) ->
+    {ok, timespan()} | {error, term()}.
 parse_timespan(MaxTime0, MinTime0) ->
     Validate = fun(Max, Min) ->
         calendar:datetime_to_gregorian_seconds(Max) >=

--- a/src/bh_route_hotspots.erl
+++ b/src/bh_route_hotspots.erl
@@ -245,7 +245,7 @@ handle('GET', [<<"hex">>, Location], Req) ->
     Args = ?GET_ARGS([cursor], Req),
     ?MK_RESPONSE(get_hotspot_list([{location_hex, Location}] ++ Args), block_time);
 handle('GET', [Address, <<"activity">>], Req) ->
-    Args = ?GET_ARGS([cursor, limit, filter_types], Req),
+    Args = ?GET_ARGS([cursor, max_time, min_time, limit, filter_types], Req),
     Result = bh_route_txns:get_activity_list({hotspot, Address}, Args),
     CacheTime = bh_route_txns:get_txn_list_cache_time(Result),
     ?MK_RESPONSE(Result, CacheTime);
@@ -253,13 +253,13 @@ handle('GET', [Address, <<"activity">>, <<"count">>], Req) ->
     Args = ?GET_ARGS([filter_types], Req),
     ?MK_RESPONSE(bh_route_txns:get_activity_count({hotspot, Address}, Args), block_time);
 handle('GET', [Address, <<"elections">>], Req) ->
-    Args = ?GET_ARGS([cursor, limit], Req),
+    Args = ?GET_ARGS([cursor, max_time, min_time, limit], Req),
     ?MK_RESPONSE(
         bh_route_elections:get_election_list({hotspot, Address}, Args),
         block_time
     );
 handle('GET', [Address, <<"challenges">>], Req) ->
-    Args = ?GET_ARGS([cursor, limit], Req),
+    Args = ?GET_ARGS([cursor, max_time, min_time, limit], Req),
     ?MK_RESPONSE(
         bh_route_challenges:get_challenge_list({hotspot, Address}, Args),
         block_time

--- a/src/bh_route_oracle.erl
+++ b/src/bh_route_oracle.erl
@@ -57,12 +57,12 @@ handle('GET', [<<"prices">>, Block], _Req) ->
 handle('GET', [<<"predictions">>], _Req) ->
     ?MK_RESPONSE(get_price_predictions(), block_time);
 handle('GET', [<<"activity">>], Req) ->
-    Args = add_filter_types(?GET_ARGS([cursor, limit], Req)),
+    Args = add_filter_types(?GET_ARGS([cursor, max_time, min_time, limit], Req)),
     Result = bh_route_txns:get_txn_list(Args),
     CacheTime = bh_route_txns:get_txn_list_cache_time(Result),
     ?MK_RESPONSE(Result, CacheTime);
 handle('GET', [Address, <<"activity">>], Req) ->
-    Args = add_filter_types(?GET_ARGS([cursor, limit], Req)),
+    Args = add_filter_types(?GET_ARGS([cursor, max_time, min_time, limit], Req)),
     Result = bh_route_txns:get_actor_txn_list({oracle, Address}, Args),
     CacheTime = bh_route_txns:get_txn_list_cache_time(Result),
     ?MK_RESPONSE(Result, CacheTime);

--- a/src/bh_route_state_channels.erl
+++ b/src/bh_route_state_channels.erl
@@ -15,7 +15,7 @@ prepare_conn(Conn) ->
     bh_db_worker:load_from_eql(Conn, "state_channels.sql", Loads).
 
 handle('GET', [], Req) ->
-    Args = add_filter_types(?GET_ARGS([cursor, limit], Req)),
+    Args = add_filter_types(?GET_ARGS([cursor, max_time, min_time, limit], Req)),
     Result = bh_route_txns:get_txn_list(Args, ?STATE_CHANNEL_TXN_LIST_LIMIT),
     CacheTime = bh_route_txns:get_txn_list_cache_time(Result),
     ?MK_RESPONSE(Result, CacheTime);

--- a/src/bh_route_validators.erl
+++ b/src/bh_route_validators.erl
@@ -132,7 +132,7 @@ handle('GET', [<<"name">>, Name], _Req) ->
 handle('GET', [Address], _Req) ->
     ?MK_RESPONSE(get_validator(Address), never);
 handle('GET', [Address, <<"activity">>], Req) ->
-    Args = ?GET_ARGS([cursor, limit, filter_types], Req),
+    Args = ?GET_ARGS([cursor, max_time, min_time, limit, filter_types], Req),
     Result = bh_route_txns:get_activity_list({validator, Address}, Args),
     CacheTime = bh_route_txns:get_txn_list_cache_time(Result),
     ?MK_RESPONSE(Result, CacheTime);

--- a/src/bh_route_vars.erl
+++ b/src/bh_route_vars.erl
@@ -26,7 +26,7 @@ prepare_conn(Conn) ->
 handle('GET', [], _Req) ->
     ?MK_RESPONSE(get_var_list(), block_time);
 handle('GET', [<<"activity">>], Req) ->
-    Args = add_filter_types(?GET_ARGS([cursor, limit], Req)),
+    Args = add_filter_types(?GET_ARGS([cursor, max_time, min_time, limit], Req)),
     Result = bh_route_txns:get_txn_list(Args),
     CacheTime = bh_route_txns:get_txn_list_cache_time(Result),
     ?MK_RESPONSE(Result, CacheTime);

--- a/test/bh_route_accounts_SUITE.erl
+++ b/test/bh_route_accounts_SUITE.erl
@@ -75,7 +75,8 @@ activity_result_test(_Config) ->
 activity_low_block_test(_Config) ->
     GetCursor = #{
         block => 50,
-        min_block => 1
+        min_block => 1,
+        max_block => 50
     },
     ct:pal("~p", [binary_to_list(?CURSOR_ENCODE(GetCursor))]),
     {ok, {_, _, Json}} = ?json_request(
@@ -96,6 +97,7 @@ activity_filter_no_result_test(_Config) ->
     GetCursor = #{
         block => 50,
         min_block => 1,
+        max_block => 50,
         types => <<"rewards_v1">>
     },
     {ok, {_, _, Json}} = ?json_request(

--- a/test/bh_route_hotspots_SUITE.erl
+++ b/test/bh_route_hotspots_SUITE.erl
@@ -104,6 +104,7 @@ activity_result_test(_Config) ->
 activity_low_block_test(_Config) ->
     GetCursor = #{
         block => 50,
+        max_block => 50,
         min_block => 1
     },
     {ok, {_, _, Json}} = ?json_request(
@@ -122,6 +123,7 @@ activity_filter_no_result_test(_Config) ->
     %% Filter for no rewards, which the given hotspot should not have
     GetCursor = #{
         block => 50,
+        max_block => 50,
         min_block => 1,
         types => <<"rewards_v1">>
     },

--- a/test/bh_route_validators_SUITE.erl
+++ b/test/bh_route_validators_SUITE.erl
@@ -91,6 +91,7 @@ activity_result_test(_Config) ->
 activity_low_block_test(_Config) ->
     GetCursor = #{
         block => 50,
+        max_block => 50,
         min_block => 1
     },
     {ok, {_, _, Json}} = ?json_request(
@@ -110,6 +111,7 @@ activity_filter_no_result_test(_Config) ->
     GetCursor = #{
         block => 50,
         min_block => 1,
+        max_block => 50,
         types => <<"rewards_v1">>
     },
     {ok, {_, _, Json}} = ?json_request(


### PR DESCRIPTION
Add min_time and max_time for ativity/txn list

-  vars (all_activity)
- validators (activity)
- oracle (activity, all_activity)
- hotspots (activity, elections, challenges)
- accounts (activity, challenges, elections)
- assert_locations
- challenges
- elections
- state_channels

Closes #311 
Part of #313 