### PR TITLE
decrease ttl on the stats page to be more in line with recent blocks 

### DIFF
--- a/src/bh_route_stats.erl
+++ b/src/bh_route_stats.erl
@@ -26,7 +26,7 @@ prepare_conn(Conn) ->
     bh_db_worker:load_from_eql(Conn, "stats.sql", Loads).
 
 handle('GET', [], _Req) ->
-    ?MK_RESPONSE(get_stats(), {block_time, 5});
+    ?MK_RESPONSE(get_stats(), {block_time, 1.5});
 handle('GET', [<<"counts">>], _Req) ->
     ?MK_RESPONSE(
         {ok,

--- a/src/bh_route_stats.erl
+++ b/src/bh_route_stats.erl
@@ -26,7 +26,7 @@ prepare_conn(Conn) ->
     bh_db_worker:load_from_eql(Conn, "stats.sql", Loads).
 
 handle('GET', [], _Req) ->
-    ?MK_RESPONSE(get_stats(), {block_time, 1.5});
+    ?MK_RESPONSE(get_stats(), {block_time, 1});
 handle('GET', [<<"counts">>], _Req) ->
     ?MK_RESPONSE(
         {ok,


### PR DESCRIPTION
The home page on helium explorer always shows up behind everything else wrt to block count. This is a popular landing zone for a lot of people. 

This command reduces the TTL for stats,  from 5 minutes to 1 minute. This should give users a more accurate view of the actual block height. 