### PR TITLE
adds max_block to account/:address

### DIFF
--- a/test/bh_route_accounts_SUITE.erl
+++ b/test/bh_route_accounts_SUITE.erl
@@ -8,6 +8,7 @@
 all() ->
     [
         get_test,
+        get_at_block_test,
         not_found_test,
         activity_count_test,
         activity_result_test,
@@ -38,6 +39,25 @@ get_test(_Config) ->
         }
     } = Json,
     ?assertEqual(FetchAddress, binary_to_list(Address)),
+    ok.
+
+get_at_block_test(_Config) ->
+    MaxBlock = 708022,
+    FetchAddress = "1122ZQigQfeeyfSmH2i4KM4XMQHouBqK4LsTp33ppP3W2Knqh8gY",
+    {ok, {_, _, Json}} = ?json_request([
+        "/v1/accounts/",
+        FetchAddress,
+        "?max_block=",
+        integer_to_list(MaxBlock)
+    ]),
+    #{
+        <<"data">> := #{
+            <<"address">> := Address,
+            <<"block">> := Block
+        }
+    } = Json,
+    ?assertEqual(FetchAddress, binary_to_list(Address)),
+    ?assertEqual(MaxBlock, Block),
     ok.
 
 not_found_test(_Config) ->


### PR DESCRIPTION
adds a max_block paremter to an account fetch to get the details of an account at a given block height

Fixes #341 