### PR TITLE
Add keys query parameter to vars

### DIFF
--- a/priv/vars.sql
+++ b/priv/vars.sql
@@ -3,3 +3,6 @@ SELECT v.name, v.type, v.value from vars_inventory v order by name
 
 -- :var_get
 SELECT v.name, v.type, v.value from vars_inventory v where v.name = $1
+
+-- :var_list_named
+SELECT v.name, v.type, v.value from vars_inventory v where v.name = ANY($1)

--- a/test/bh_route_vars_SUITE.erl
+++ b/test/bh_route_vars_SUITE.erl
@@ -3,11 +3,13 @@
 
 -include("ct_utils.hrl").
 
-all() -> [
-          name_test,
-          list_test,
-          activity_list_test
-         ].
+all() ->
+    [
+        name_test,
+        list_test,
+        list_named_test,
+        activity_list_test
+    ].
 
 init_per_suite(Config) ->
     ?init_bh(Config).
@@ -16,27 +18,42 @@ end_per_suite(Config) ->
     ?end_bh(Config).
 
 name_test(_Config) ->
-    Names = ["poc_version", % integer
-             "securities_percent", % float
-             "predicate_callback_mod", % atom
-             "price_oracle_public_keys" % oracle keys
-            ],
-    lists:foreach(fun(Name) ->
-                          {ok, {_, _, Json}} = ?json_request(["/v1/vars/", Name]),
-                          ?assertMatch(#{ <<"data">> := _ }, Json)
-                  end, Names),
+    % integer
+    Names = [
+        "poc_version",
+        % float
+        "securities_percent",
+        % atom
+        "predicate_callback_mod",
+        % oracle keys
+        "price_oracle_public_keys"
+    ],
+    lists:foreach(
+        fun(Name) ->
+            {ok, {_, _, Json}} = ?json_request(["/v1/vars/", Name]),
+            ?assertMatch(#{<<"data">> := _}, Json)
+        end,
+        Names
+    ),
     ok.
 
 list_test(_Config) ->
     {ok, {_, _, Json}} = ?json_request("/v1/vars"),
-    #{ <<"data">> := Data } = Json,
+    #{<<"data">> := Data} = Json,
     ?assert(map_size(Data) >= 0),
+
+    ok.
+
+list_named_test(_Config) ->
+    {ok, {_, _, Json}} = ?json_request("/v1/vars?keys=poc_version,securities_percent"),
+    #{<<"data">> := Data} = Json,
+    ?assertEqual(2, map_size(Data)),
 
     ok.
 
 activity_list_test(_Config) ->
     {ok, {_, _, AllJson}} = ?json_request("/v1/vars/activity"),
-    #{ <<"data">> := AllData } = AllJson,
+    #{<<"data">> := AllData} = AllJson,
     ?assert(length(AllData) >= 0),
 
     ok.


### PR DESCRIPTION
Fixes #348 

on `/v1/vars` you can now pass in a comma separated list of key names to fetch. Max number of keys to request is currently set to 50. You can Keys that do not exist are ignored. 

e.g. 

`/v1/vars?keys=poc_version,securities_percent`