### PR TITLE
Filters out the large region_ vars

### DIFF
--- a/priv/vars.sql
+++ b/priv/vars.sql
@@ -1,5 +1,11 @@
 -- :var_list
-SELECT v.name, v.type, v.value from vars_inventory v order by name
+SELECT 
+    v.name, 
+    v.type, 
+    v.value 
+from vars_inventory v 
+where v.name not like 'region_%'
+order by name
 
 -- :var_get
 SELECT v.name, v.type, v.value from vars_inventory v where v.name = $1


### PR DESCRIPTION
Regional parameters are relative large binary entries on chain which can cuase issues for apps/browsers with limited memory since most of them request a full list of chain variables.

Chain variables the begin with region_ are filtered out of the main vars list with this PR. They can still be retrieved if the name of the variable is known using `/var/v1/vars?keys` or `/var/v1/:key`