### PR TITLE
bumping versions; updating OTP to 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   CI:
     runs-on: ubuntu-latest
-    container: heliumsystems/builder-erlang:1
+    container: heliumsystems/builder-erlang:2
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,15 @@ on:
 jobs:
   CI:
     runs-on: ubuntu-latest
-    container: heliumsystems/builder-erlang:2
 
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Setup
+        uses: erlef/setup-beam@v1
+        with:
+          otp-version: 24
 
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.5.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,18 +14,24 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Setup
+      - name: Setup erlang
         uses: erlef/setup-beam@v1
         with:
           otp-version: 24
+
+      - name: Setup rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          default: true
 
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.5.0
         with:
           access_token: ${{ github.token }}
 
-      - name: Rust Toolchain
-        run: rustup default stable
+      - name: Install build deps
+        run: sudo apt install libsodium-dev
 
       - name: Cache Hex Packages
         if: ${{ !env.ACT }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   package:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM erlang:24.1.6.0-alpine as builder
+FROM erlang:24-alpine as builder
 
 WORKDIR /app
 ENV REBAR_BASE_DIR /app/_build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM erlang:23.3.4.8-alpine as builder
+FROM erlang:24.1.6.0-alpine as builder
 
 WORKDIR /app
 ENV REBAR_BASE_DIR /app/_build
@@ -22,7 +22,7 @@ RUN mkdir -p /opt/rel && \
     ./rebar3 as prod tar && \
     tar -zxvf $REBAR_BASE_DIR/prod/rel/*/*.tar.gz -C /opt/rel
 
-FROM alpine:3.13 as runner
+FROM alpine:3.14 as runner
 
 RUN apk add --update openssl libsodium ncurses libstdc++
 


### PR DESCRIPTION
Updating default release version of OTP backing HTTP API to v24 for much speed.