### PR TITLE
Improve witnessed query performance

### DIFF
--- a/priv/hotspots.sql
+++ b/priv/hotspots.sql
@@ -156,7 +156,8 @@ hotspot_witnessed as (
     select actor as witnessed
     from transaction_actors 
     where transaction_hash in (select transaction_hash from recent_transactions)
-    and actor_role = 'challengee'
+        and actor_role = 'challengee'
+        and block >= (select height from five_days)
     group by actor
  )
 :hotspot_select


### PR DESCRIPTION
Witnessed query takes too long and cause /hotspots/:address/witnessed API calls to fail. This commit is adding block limiting to the hotspot_witnessed / transaction_actors query. The same limitation is already in place for recent_transactions query. 