### PR TITLE
Use blockspan helper to infer five day window

### DIFF
--- a/src/bh_route_hotspots.erl
+++ b/src/bh_route_hotspots.erl
@@ -336,10 +336,12 @@ get_hotspot_list_by_distance([{lat, _}, {lon, _}, {distance, _}, {cursor, Cursor
     get_hotspot_list([{search_distance, []}, {cursor, Cursor}]).
 
 get_hotspot_list([{witnesses_for, Address}]) ->
-    Result = ?PREPARED_QUERY(?S_HOTSPOT_WITNESS_LIST, [Address]),
+    {ok, {_, {_MaxBlock, MinBlock}}} = bh_route_blocks:get_block_span(undefined, <<"-5 day">>),
+    Result = ?PREPARED_QUERY(?S_HOTSPOT_WITNESS_LIST, [Address, MinBlock]),
     mk_hotspot_witness_list_from_result(Result);
 get_hotspot_list([{witnessed_for, Address}]) ->
-    Result = ?PREPARED_QUERY(?S_HOTSPOT_WITNESSED_LIST, [Address]),
+    {ok, {_, {_MaxBlock, MinBlock}}} = bh_route_blocks:get_block_span(undefined, <<"-5 day">>),
+    Result = ?PREPARED_QUERY(?S_HOTSPOT_WITNESSED_LIST, [Address, MinBlock]),
     mk_hotspot_witness_list_from_result(Result);
 get_hotspot_list([
     {owner, undefined},

--- a/test/ct_utils.erl
+++ b/test/ct_utils.erl
@@ -11,7 +11,9 @@ init_bh(Config) ->
     application:load(blockchain_http),
     application:set_env(blockchain_http, throttle, #{
         request_time => 10000000000,
-        request_interval => 10
+        request_interval => 10,
+        %% how many requests are allowed
+        request_count => 1000
     }),
     {ok, Pid} = bh_sup:start_link(),
     unlink(Pid),


### PR DESCRIPTION
Use blockspan helper to calculate the 5 day low block. 

This should add another speed improvement to https://github.com/helium/blockchain-http/pull/365