### PR TITLE
Removing a typo in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ release:
 
 start:
 	cp -f .env ./_build/prod/rel/blockchain_http/
-	./_build/prod/rel/blockchain_http/bin/blockchain_http daemon
+	./_build/prod/rel/blockchain_http/bin/blockchain_http foreground
 
 stop:
 	-./_build/prod/rel/blockchain_http/bin/blockchain_http stop

--- a/Makefile
+++ b/Makefile
@@ -44,13 +44,13 @@ release:
 
 start:
 	cp -f .env ./_build/prod/rel/blockchain_http/
-	./_build/prod/rel/blockchain_http/bin/blockchain_http foreground
+	./_build/prod/rel/blockchain_http/bin/blockchain_http daemon
 
 stop:
 	-./_build/prod/rel/blockchain_http/bin/blockchain_http stop
 
 reset: stop
-	rm -rf rm -rf ./_build/prod/rel/blockchain_http/log/*
+	rm -rf ./_build/prod/rel/blockchain_http/log/*
 
 console:
 	./_build/prod/rel/blockchain_http/bin/blockchain_http remote_console


### PR DESCRIPTION
`make start` starts in daemon mode to release the shell prompt. 

Also removing a typo for `rm -rf` 