### PR TITLE
Madninja/txn actor filter

### DIFF
--- a/priv/txns.sql
+++ b/priv/txns.sql
@@ -20,6 +20,9 @@ and block >= $2 and block < $3
 -- :txn_list_fields
 t.fields
 
+-- :txn_actor_list_fields
+txn_filter_actor_activity($2, t.type, t.fields) as fields
+
 -- :txn_list_order
 order by t.block desc, t.hash
 

--- a/test/bh_route_txns_SUITE.erl
+++ b/test/bh_route_txns_SUITE.erl
@@ -1,0 +1,54 @@
+-module(bh_route_txns_SUITE).
+-compile([nowarn_export_all, export_all]).
+
+-include("ct_utils.hrl").
+
+all() ->
+    [
+        get_test,
+        get_actor_test
+    ].
+
+init_per_suite(Config) ->
+    ?init_bh(Config).
+
+end_per_suite(Config) ->
+    ?end_bh(Config).
+
+get_test(_Config) ->
+    TxnHash = "DmTG-Nbp6rLr4ERjqOvBcDC-94G4qsWg-Ii9BeL2qhY",
+    {ok, {_, _, Json}} = ?json_request([
+        "/v1/transactions/",
+        TxnHash
+    ]),
+    ?assertMatch(#{<<"data">> := _}, Json),
+    ok.
+
+get_actor_test(_Config) ->
+    TxnHash = "ks_-16PtsDQo7zWgdFoucKw4AA4pj5dvUzv17gSdU0o",
+    Actor = "14fkPiFHh6oqecKhkjRWTtcJByy44t5S68SZQG6QExtStSQAZsr",
+    {ok, {_, _, Json}} = ?json_request([
+        "/v1/transactions/",
+        TxnHash,
+        "?actor=",
+        Actor
+    ]),
+    #{
+        <<"data">> := #{
+            <<"rewards">> := Rewards
+        }
+    } = Json,
+    ?assertMatch(
+        [
+            #{
+                <<"account">> :=
+                    <<"14fkPiFHh6oqecKhkjRWTtcJByy44t5S68SZQG6QExtStSQAZsr">>,
+                <<"gateway">> :=
+                    <<"112jbxsCXERvuu6Xq3cjJUBpoKSwLsUuUGNF5wgh8cgj8Vsf5guV">>,
+                <<"amount">> := _,
+                <<"type">> := <<"poc_witnesses">>
+            }
+        ],
+        Rewards
+    ),
+    ok.


### PR DESCRIPTION
Adds a `actor` query parameter to filter a given transaction json for just the requested "actors". This is mostly useful for poc_receipts and rewards transactions which may contain a lot of data that is not relevant to a specific hotspot/account/validator. 

Fixes #379 