### PR TITLE
adding .git directory to be ignored from docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@ LICENSE
 CONTRIBUTING.md
 Dockerfile
 Makefile
+.git/


### PR DESCRIPTION
Avoiding sending .git directory into the docker build context