### PR TITLE
relx needs .git for the tags

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,4 +4,3 @@ LICENSE
 CONTRIBUTING.md
 Dockerfile
 Makefile
-.git/


### PR DESCRIPTION
We aren't able to dockerignore the .git directory b/c relx uses the tags when determining the semver version number for the application release. This shouldn't be a big problem unless we're ever doing docker builds on remote hosts from where the code is checked out to but should be kept in mind the bigger the .git directory gets over time.