### PR TITLE
Add /v1/[accounts|hotspots]/:address/rewards/:block

### DIFF
--- a/priv/rewards.sql
+++ b/priv/rewards.sql
@@ -1,10 +1,10 @@
 -- :reward_fields
-r.block, r.transaction_hash, to_timestamp(r.time) as timestamp, r.account, r.gateway, r.amount
+r.block, r.transaction_hash, to_timestamp(r.time) as timestamp, r.account, r.gateway, r.amount, r.type
 
 -- Make sure that marker fields and fields are equivalent except for the marker
 -- placeholder!
 -- :reward_marker_fields
-r.block, r.transaction_hash, to_timestamp(r.time) as timestamp, r.account, r.gateway, r.amount, :marker
+r.block, r.transaction_hash, to_timestamp(r.time) as timestamp, r.account, r.gateway, r.amount, r.type, :marker
 
 -- :reward_list_base
 select :fields
@@ -19,6 +19,14 @@ from rewards r
 :scope
 and r.block = $2 and :marker> $3
 order by :marker
+
+-- :reward_block_list_base
+select :fields
+from rewards r 
+:scope 
+and r.block = $2
+order by r.gateway, r.type
+offset $3 fetch next $4 rows only
 
 -- :reward_sum_hotspot_source
 (select

--- a/src/bh_route_accounts.erl
+++ b/src/bh_route_accounts.erl
@@ -147,6 +147,18 @@ handle('GET', [Account, <<"rewards">>], Req) ->
 handle('GET', [Account, <<"rewards">>, <<"sum">>], Req) ->
     Args = ?GET_ARGS([max_time, min_time, bucket], Req),
     ?MK_RESPONSE(bh_route_rewards:get_reward_sum({account, Account}, Args), block_time);
+handle('GET', [Account, <<"rewards">>, Block], Req) ->
+    Args = ?GET_ARGS([cursor], Req),
+    bh_route_handler:try_or_else(
+        fun() -> binary_to_integer(Block) end,
+        fun(Height) ->
+            ?MK_RESPONSE(
+                bh_route_rewards:get_reward_list({account, Account}, Args ++ [{block, Height}]),
+                infinity
+            )
+        end,
+        ?RESPONSE_400
+    );
 handle('GET', [Account, <<"pending_transactions">>], Req) ->
     Args = ?GET_ARGS([cursor], Req),
     ?MK_RESPONSE(bh_route_pending_txns:get_pending_txn_list({actor, Account}, Args), never);

--- a/src/bh_route_hotspots.erl
+++ b/src/bh_route_hotspots.erl
@@ -324,6 +324,18 @@ handle('GET', [Address, <<"rewards">>], Req) ->
 handle('GET', [Address, <<"rewards">>, <<"sum">>], Req) ->
     Args = ?GET_ARGS([max_time, min_time, bucket], Req),
     ?MK_RESPONSE(bh_route_rewards:get_reward_sum({hotspot, Address}, Args), block_time);
+handle('GET', [Address, <<"rewards">>, Block], Req) ->
+    Args = ?GET_ARGS([cursor], Req),
+    bh_route_handler:try_or_else(
+        fun() -> binary_to_integer(Block) end,
+        fun(Height) ->
+            ?MK_RESPONSE(
+                bh_route_rewards:get_reward_list({hotspot, Address}, Args ++ [{block, Height}]),
+                infinity
+            )
+        end,
+        ?RESPONSE_400
+    );
 handle('GET', [<<"rewards">>, <<"sum">>], Req) ->
     %% We do not allow bucketing across all hotspots as that takes way too long
     Args = ?GET_ARGS([max_time, min_time], Req),

--- a/test/bh_route_accounts_SUITE.erl
+++ b/test/bh_route_accounts_SUITE.erl
@@ -25,6 +25,7 @@ all() ->
         rewards_dupe_test,
         rewards_sum_test,
         rewards_buckets_test,
+        rewards_block_test,
         rich_list_test
     ].
 
@@ -258,6 +259,29 @@ rewards_test(_Config) ->
             #{<<"data">> := CursorData} = CursorJson,
             ?assert(length(CursorData) >= 0)
     end,
+
+    ok.
+
+rewards_block_test(_Config) ->
+    Account = "13ESLoXiie3eXoyitxryNQNamGAnJjKt2WkiB4gNq95knxAiGEp",
+    {ok, {_, _, Json}} =
+        ?json_request([
+            "/v1/accounts/",
+            Account,
+            "/rewards/1167207"
+        ]),
+    #{<<"data">> := Data, <<"cursor">> := Cursor} = Json,
+    ?assert(length(Data) >= 0),
+
+    {ok, {_, _, CursorJson}} =
+        ?json_request([
+            "/v1/accounts/",
+            Account,
+            "/rewards/1167207?cursor=",
+            Cursor
+        ]),
+    #{<<"data">> := CursorData} = CursorJson,
+    ?assert(length(CursorData) >= 0),
 
     ok.
 

--- a/test/bh_route_hotspots_SUITE.erl
+++ b/test/bh_route_hotspots_SUITE.erl
@@ -28,6 +28,7 @@ all() ->
         rewards_all_sum_test,
         rewards_sum_test,
         rewards_buckets_test,
+        rewards_block_test,
         witnesses_test,
         witnessed_test,
         witnesses_buckets_test,
@@ -298,6 +299,18 @@ rewards_test(_Config) ->
             #{<<"data">> := CursorData} = CursorJson,
             ?assert(length(CursorData) >= 0)
     end,
+    ok.
+
+rewards_block_test(_Config) ->
+    Hotspot = "112WaLcxSnEQTSTiyB46ey4WVr9SUiYcCjrFRXYcv1mp9bdobDxR",
+    {ok, {_, _, Json}} =
+        ?json_request([
+            "/v1/hotspots/",
+            Hotspot,
+            "/rewards/1167207"
+        ]),
+    #{<<"data">> := Data} = Json,
+    ?assert(length(Data) >= 0),
     ok.
 
 rewards_all_sum_test(_Config) ->


### PR DESCRIPTION
This returns the rewards for a given hotspot/account in the given rewards block. 

This requires https://github.com/helium/blockchain-etl/pull/289 to be merged, deployed, and migrations run