### PR TITLE
Allow for witness with no location

### DIFF
--- a/src/bh_route_handler.erl
+++ b/src/bh_route_handler.erl
@@ -251,6 +251,8 @@ lat_lon(Location, {LatName, LonName}, Fields) when is_binary(Location) ->
 insert_location_hex(Location, Fields) ->
     insert_location_hex(Location, <<"location_hex">>, Fields).
 
+insert_location_hex(undefined, _Name, Fields) ->
+    Fields;
 insert_location_hex(Location, Name, Fields) ->
     Fields#{Name => to_location_hex(Location)}.
 


### PR DESCRIPTION
As part of the offchain PoC switch a series of witnesses with no asserted location  were allowed onto the chain.

This patch prevents the api from erroring out when this happens.